### PR TITLE
Refactor fixed-point system time and ranging calculations.

### DIFF
--- a/src/dw1000-ranging-double_sided.adb
+++ b/src/dw1000-ranging-double_sided.adb
@@ -20,6 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
+with DW1000.Types; use DW1000.Types;
+
 package body DW1000.Ranging.Double_Sided
 with SPARK_Mode => On
 is
@@ -31,56 +33,62 @@ is
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Final_Timestamp : in Fine_System_Time) return Biased_Distance
    is
-      --  Subtypes to help GNATprove prove absence of runtime errors.
-      subtype System_Time_Span_Float is Long_Float
-      range 0.0 .. Long_Float (System_Time_Span'Last);
+      type System_Time_Span_Div2 is
+      delta System_Time_Span'Delta / 2.0
+      range 0.0 .. System_Time_Span'Last --  need the same range as System_Time_Span
+        with Small => System_Time_Span'Small / 2.0;
 
-      subtype Time_Of_Flight_Float is Long_Float
-      range 0.0 .. System_Time_Span_Float'Last / 2.0;
+      type System_Time_Span_Div4 is
+      delta System_Time_Span'Delta / 4.0
+      range 0.0 .. System_Time_Span'Last / 2.0
+        with Small => System_Time_Span'Small / 4.0;
 
-      subtype Distance_Float is Long_Float
-      range 0.0 .. Time_Of_Flight_Float'Last * Speed_Of_Light_In_Air;
+      T_Roundtrip1 : constant System_Time_Span := Calculate_Span
+        (Start_Time => Tag_Tx_Poll_Timestamp,
+         End_Time   => Tag_Rx_Resp_Timestamp);
 
-      T_Roundtrip1 : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Tag_Tx_Poll_Timestamp,
-            End_Time   => Tag_Rx_Resp_Timestamp));
+      T_Reply1 : constant System_Time_Span := Calculate_Span
+        (Start_Time => Anchor_Rx_Poll_Timestamp,
+         End_Time   => Anchor_Tx_Resp_Timestamp);
 
-      T_Reply1 : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Anchor_Rx_Poll_Timestamp,
-            End_Time   => Anchor_Tx_Resp_Timestamp));
+      T_Roundtrip2 : constant System_Time_Span := Calculate_Span
+        (Start_Time => Anchor_Tx_Resp_Timestamp,
+         End_Time   => Anchor_Rx_Final_Timestamp);
 
-      T_Roundtrip2 : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Anchor_Tx_Resp_Timestamp,
-            End_Time   => Anchor_Rx_Final_Timestamp));
+      T_Reply2 : constant System_Time_Span := Calculate_Span
+        (Start_Time => Tag_Rx_Resp_Timestamp,
+         End_Time   => Tag_Tx_Final_Timestamp);
 
-      T_Reply2 : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Tag_Rx_Resp_Timestamp,
-            End_Time   => Tag_Tx_Final_Timestamp));
+      Time_Of_Flight_1 : System_Time_Span_Div2;
+      Time_Of_Flight_2 : System_Time_Span_Div2;
+      Time_Of_Flight   : System_Time_Span_Div4;
 
-      Time_Of_Flight_1 : Time_Of_Flight_Float;
-      Time_Of_Flight_2 : Time_Of_Flight_Float;
-      Time_Of_Flight   : Time_Of_Flight_Float;
+      Diff : System_Time_Span;
+      Sum  : System_Time_Span_Div2;
 
-      Result : Distance_Float;
+      TOF_I41   : Bits_41;
+      TOF_Float : Long_Float;
 
    begin
       if (T_Reply1 > T_Roundtrip1) or (T_Reply2 > T_Roundtrip2) then
          Time_Of_Flight := 0.0;
 
       else
-         Time_Of_Flight_1 := (T_Roundtrip1 - T_Reply1) / 2.0;
-         Time_Of_Flight_2 := (T_Roundtrip2 - T_Reply2) / 2.0;
+         Diff := T_Roundtrip1 - T_Reply1;
+         Time_Of_Flight_1 := System_Time_Span_Div2 (Diff / System_Time_Span (2.0));
 
-         Time_Of_Flight := (Time_Of_Flight_1 + Time_Of_Flight_2) / 2.0;
+         Diff := T_Roundtrip2 - T_Reply2;
+         Time_Of_Flight_2 := System_Time_Span_Div2 (Diff / System_Time_Span (2.0));
+
+         Sum := Time_Of_Flight_1 + Time_Of_Flight_2;
+         Time_Of_Flight := System_Time_Span_Div4 (Sum / System_Time_Span_Div4 (2.0));
       end if;
 
-      Result := Distance_Float (Time_Of_Flight * Speed_Of_Light_In_Air);
+      --  Convert to floating point
+      TOF_I41   := Bits_41 (Time_Of_Flight / System_Time_Span_Div4 (System_Time_Span_Div4'Delta));
+      TOF_Float := Long_Float (TOF_I41) * System_Time_Span_Div4'Delta;
 
-      return Biased_Distance (Result);
+      return Biased_Distance (TOF_Float * Speed_Of_Light_In_Air);
    end Compute_Distance;
 
 

--- a/src/dw1000-ranging-double_sided.adb
+++ b/src/dw1000-ranging-double_sided.adb
@@ -92,7 +92,7 @@ is
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Final_Timestamp : in Fine_System_Time;
       Channel                   : in DW1000.Driver.Channel_Number;
-      PRF                       : in DW1000.Driver.PRF_Type) return Distance
+      PRF                       : in DW1000.Driver.PRF_Type) return Meters
    is
       Distance_With_Bias : Biased_Distance;
 

--- a/src/dw1000-ranging-double_sided.ads
+++ b/src/dw1000-ranging-double_sided.ads
@@ -69,7 +69,7 @@ is
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Final_Timestamp : in Fine_System_Time;
       Channel                   : in DW1000.Driver.Channel_Number;
-      PRF                       : in DW1000.Driver.PRF_Type) return Distance
+      PRF                       : in DW1000.Driver.PRF_Type) return Meters
      with Global => null;
    --  Compute the distance based on a double-sided ranging exchange, and
    --  automatically remove ranging bias.

--- a/src/dw1000-ranging-single_sided.adb
+++ b/src/dw1000-ranging-single_sided.adb
@@ -73,7 +73,7 @@ is
       Anchor_Tx_Resp_Timestamp : in Fine_System_Time;
       Tag_Rx_Resp_Timestamp    : in Fine_System_Time;
       Channel                  : in DW1000.Driver.Channel_Number;
-      PRF                      : in DW1000.Driver.PRF_Type) return Distance
+      PRF                      : in DW1000.Driver.PRF_Type) return Meters
    is
       Distance_With_Bias : Biased_Distance;
 

--- a/src/dw1000-ranging-single_sided.adb
+++ b/src/dw1000-ranging-single_sided.adb
@@ -20,6 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
+with DW1000.Types; use DW1000.Types;
+
 package body DW1000.Ranging.Single_Sided
 with SPARK_Mode => On
 is
@@ -29,41 +31,40 @@ is
       Anchor_Tx_Resp_Timestamp : in Fine_System_Time;
       Tag_Rx_Resp_Timestamp    : in Fine_System_Time) return Biased_Distance
    is
-      --  Subtypes to help GNATprove prove absence of runtime errors.
-      subtype System_Time_Span_Float is Long_Float
-      range 0.0 .. Long_Float (System_Time_Span'Last);
+      type System_Time_Span_Div2 is
+      delta System_Time_Span'Delta / 2.0
+      range 0.0 .. System_Time_Span'Last / 2.0
+        with Small => System_Time_Span'Small / 2.0;
 
-      subtype Time_Of_Flight_Float is Long_Float
-      range 0.0 .. System_Time_Span_Float'Last / 2.0;
+      T_Tag : constant System_Time_Span := Calculate_Span
+        (Start_Time => Tag_Tx_Poll_Timestamp,
+         End_Time   => Tag_Rx_Resp_Timestamp);
 
-      subtype Distance_Float is Long_Float
-      range 0.0 .. Time_Of_Flight_Float'Last * Speed_Of_Light_In_Air;
+      T_Anchor : constant System_Time_Span := Calculate_Span
+        (Start_Time => Anchor_Rx_Poll_Timestamp,
+         End_Time   => Anchor_Tx_Resp_Timestamp);
 
-      T_Tag : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Tag_Tx_Poll_Timestamp,
-            End_Time   => Tag_Rx_Resp_Timestamp));
+      Diff : System_Time_Span;
 
-      T_Anchor : constant System_Time_Span_Float := System_Time_Span_Float
-        (Calculate_Span
-           (Start_Time => Anchor_Rx_Poll_Timestamp,
-            End_Time   => Anchor_Tx_Resp_Timestamp));
+      Time_Of_Flight : System_Time_Span_Div2;
 
-      Time_Of_Flight : Time_Of_Flight_Float;
-
-      Result : Distance_Float;
+      TOF_I40   : Bits_40;
+      TOF_Float : Long_Float;
 
    begin
       if T_Anchor >= T_Tag then
          Time_Of_Flight := 0.0;
 
       else
-         Time_Of_Flight := (T_Tag - T_Anchor) / 2.0;
+         Diff := T_Tag - T_Anchor;
+         Time_Of_Flight := System_Time_Span_Div2 (Diff / System_Time_Span (2.0));
       end if;
 
-      Result := Distance_Float (Time_Of_Flight * Speed_Of_Light_In_Air);
+      --  Convert to floating point
+      TOF_I40   := Bits_40 (Time_Of_Flight / System_Time_Span_Div2 (System_Time_Span_Div2'Delta));
+      TOF_Float := Long_Float (TOF_I40) * System_Time_Span_Div2'Delta;
 
-      return Biased_Distance (Result);
+      return Biased_Distance (TOF_Float * Speed_Of_Light_In_Air);
    end Compute_Distance;
 
 

--- a/src/dw1000-ranging-single_sided.ads
+++ b/src/dw1000-ranging-single_sided.ads
@@ -58,7 +58,7 @@ is
       Anchor_Tx_Resp_Timestamp : in Fine_System_Time;
       Tag_Rx_Resp_Timestamp    : in Fine_System_Time;
       Channel                  : in DW1000.Driver.Channel_Number;
-      PRF                      : in DW1000.Driver.PRF_Type) return Distance
+      PRF                      : in DW1000.Driver.PRF_Type) return Meters
      with Global => null;
    --  Compute the distance based on a single-sided ranging exchange, and
    --  automatically remove ranging bias.

--- a/src/dw1000-ranging.adb
+++ b/src/dw1000-ranging.adb
@@ -625,21 +625,6 @@ is
 
    end Lookup_Correction;
 
-   -------------------
-   --  To_Distance  --
-   -------------------
-
-   function To_Distance (Time_Of_Flight : in System_Time_Span) return Meters
-   is
-      Fine : constant Fine_System_Time := Fine_System_Time (Time_Of_Flight);
-      TOF  : Long_Float;
-
-   begin
-      TOF := Long_Float (To_Bits_40 (Fine)) * System_Time_Span'Delta;
-
-      return Meters (TOF * Speed_Of_Light_In_Air);
-   end To_Distance;
-
    ---------------------------
    --  Remove_Ranging_Bias  --
    ---------------------------

--- a/src/dw1000-ranging.adb
+++ b/src/dw1000-ranging.adb
@@ -26,39 +26,33 @@ package body DW1000.Ranging
 with SPARK_Mode => On
 is
 
-   Nb_16MHz_Corrections_Narrowband : constant := 37;
-   Nb_16MHz_Corrections_Wideband   : constant := 68;
-   Nb_64MHz_Corrections_Narrowband : constant := 26;
-   Nb_64MHz_Corrections_Wideband   : constant := 59;
-
    type Short_Distance is
    delta 0.25
    range 0.0 .. 63.75
-     with Small => 0.25,
-     Size => 8;
+     with Size => 8;
 
    type Correction_Table is array (Natural range <>) of Short_Distance;
 
-   subtype Correction_Distance is Distance range 0.0 .. 0.68;
-
-   subtype Correction_Table_16MHz_Narrowband is
-     Correction_Table (Natural range 0 .. Nb_16MHz_Corrections_Narrowband - 1);
-
-   subtype Correction_Table_16MHz_Wideband is
-     Correction_Table (Natural range 0 .. Nb_16MHz_Corrections_Wideband - 1);
-
-   subtype Correction_Table_64MHz_Narrowband is
-     Correction_Table (Natural range 0 .. Nb_64MHz_Corrections_Narrowband - 1);
-
-   subtype Correction_Table_64MHz_Wideband is
-     Correction_Table (Natural range 0 .. Nb_64MHz_Corrections_Wideband - 1);
+   subtype Correction_Distance is Meters range 0.0 .. 0.68;
+   --  Subtype to constrain the maximum amount of correction that is applied.
 
    Offset_16MHz_Narrowband : constant Correction_Distance := 0.23;
    Offset_16MHz_Wideband   : constant Correction_Distance := 0.28;
    Offset_64MHz_Narrowband : constant Correction_Distance := 0.17;
    Offset_64MHz_Wideband   : constant Correction_Distance := 0.30;
 
-   Correction_Table_Ch1_16MHz : constant Correction_Table_16MHz_Narrowband
+   -------------------------
+   --  Correction Tables  --
+   -------------------------
+
+   --  These lookup tables are used to determine the correction value needed
+   --  to remove the ranging bias from the raw distance measurements.
+   --
+   --  Each entry in the table is a threshold value, in meters. The index of
+   --  the array element is the correction value needed in centimeters for that
+   --  threshold value.
+
+   Correction_Table_Ch1_16MHz : constant Correction_Table
      := (0  =>  0.25,
          1  =>  0.75,
          2  =>  1.00,
@@ -98,7 +92,7 @@ is
          36 => 63.75);
 
 
-   Correction_Table_Ch2_16MHz : constant Correction_Table_16MHz_Narrowband
+   Correction_Table_Ch2_16MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.50,
          2 => 1.00,
@@ -137,7 +131,7 @@ is
          35 => 60.00,
          36 => 63.75);
 
-   Correction_Table_Ch3_16MHz : constant Correction_Table_16MHz_Narrowband
+   Correction_Table_Ch3_16MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.50,
          2 => 0.75,
@@ -176,7 +170,7 @@ is
          35 => 53.25,
          36 => 63.75);
 
-   Correction_Table_Ch4_16MHz : constant Correction_Table_16MHz_Wideband
+   Correction_Table_Ch4_16MHz : constant Correction_Table
      := (0 => 1.75,
          1 => 1.75,
          2 => 2.00,
@@ -246,7 +240,7 @@ is
          66 => 63.75,
          67 => 63.75);
 
-   Correction_Table_Ch5_16MHz : constant Correction_Table_16MHz_Narrowband
+   Correction_Table_Ch5_16MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.25,
          2 => 0.50,
@@ -285,7 +279,7 @@ is
          35 => 37.00,
          36 => 63.75);
 
-   Correction_Table_Ch7_16MHz : constant Correction_Table_16MHz_Wideband
+   Correction_Table_Ch7_16MHz : constant Correction_Table
      := (0 => 1.00,
          1 => 1.25,
          2 => 1.25,
@@ -355,7 +349,7 @@ is
          66 => 51.25,
          67 => 63.75);
 
-   Correction_Table_Ch1_64MHz : constant Correction_Table_64MHz_Narrowband
+   Correction_Table_Ch1_64MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.50,
          2 => 0.50,
@@ -383,7 +377,7 @@ is
          24 => 39.25,
          25 => 63.75);
 
-   Correction_Table_Ch2_64MHz : constant Correction_Table_64MHz_Narrowband
+   Correction_Table_Ch2_64MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.50,
          2 => 0.50,
@@ -411,7 +405,7 @@ is
          24 => 34.50,
          25 => 63.75);
 
-   Correction_Table_Ch3_64MHz : constant Correction_Table_64MHz_Narrowband
+   Correction_Table_Ch3_64MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.25,
          2 => 0.50,
@@ -439,7 +433,7 @@ is
          24 => 30.50,
          25 => 63.75);
 
-   Correction_Table_Ch4_64MHz : constant Correction_Table_64MHz_Wideband
+   Correction_Table_Ch4_64MHz : constant Correction_Table
      := (0 => 1.75,
          1 => 2.00,
          2 => 2.00,
@@ -500,7 +494,7 @@ is
          57 => 63.75,
          58 => 63.75);
 
-   Correction_Table_Ch5_64MHz : constant Correction_Table_64MHz_Narrowband
+   Correction_Table_Ch5_64MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.25,
          2 => 0.25,
@@ -528,7 +522,7 @@ is
          24 => 21.25,
          25 => 63.75);
 
-   Correction_Table_Ch7_64MHz : constant Correction_Table_64MHz_Wideband
+   Correction_Table_Ch7_64MHz : constant Correction_Table
      := (0 => 1.00,
          1 => 1.25,
          2 => 1.25,
@@ -589,8 +583,11 @@ is
          57 => 48.00,
          58 => 63.75);
 
+   -------------------------
+   --  Lookup_Correction  --
+   -------------------------
 
-   function Lookup_Correction (Measured_Distance : in Distance;
+   function Lookup_Correction (Measured_Distance : in Meters;
                                Table           : in Correction_Table)
                                return Correction_Distance
      with Global => null,
@@ -601,21 +598,20 @@ is
       I : Natural;
 
    begin
-      if Measured_Distance > Distance (Short_Distance'Last) then
+      if Measured_Distance > Meters (Short_Distance'Last) then
          Distance_25cm := Short_Distance'Last;
 
       else
          --  Workaround since GNATprove does not yet support conversions
-         --  between different fixed-point types.
+         --  between different fixed-point and floating-point types.
          --
          --  This is equivalent to:
-         --     Distance_25cm := Bias (Measured_Distance);
+         --     Distance_25cm := Short_Distance (Measured_Distance);
          Distance_25cm :=
-           Short_Distance'Delta * Integer (Measured_Distance / Distance (Short_Distance'Delta));
+           Short_Distance'Delta * Integer (Measured_Distance / Short_Distance'Delta);
       end if;
 
-      --  Find the index of the table entry which matches
-      --  the estimated distance.
+      --  Find the index of the table entry which matches the estimated distance.
       I := 0;
       while I < Table'Length loop
          pragma Loop_Variant (Increases => I);
@@ -624,23 +620,41 @@ is
          I := I + 1;
       end loop;
 
-      --  The index is the correction needed in increments of 25 cm.
-      return Correction_Distance (0.01) * Distance (I);
+      --  The index is the correction needed in centimeters.
+      return Correction_Distance (0.01) * Meters (I);
 
    end Lookup_Correction;
 
+   -------------------
+   --  To_Distance  --
+   -------------------
+
+   function To_Distance (Time_Of_Flight : in System_Time_Span) return Meters
+   is
+      Fine : constant Fine_System_Time := Fine_System_Time (Time_Of_Flight);
+      TOF  : Long_Float;
+
+   begin
+      TOF := Long_Float (To_Bits_40 (Fine)) * System_Time_Span'Delta;
+
+      return Meters (TOF * Speed_Of_Light_In_Air);
+   end To_Distance;
+
+   ---------------------------
+   --  Remove_Ranging_Bias  --
+   ---------------------------
 
    function Remove_Ranging_Bias
      (Measured_Distance : in Biased_Distance;
       Channel           : in DW1000.Driver.Channel_Number;
-      PRF               : in DW1000.Driver.PRF_Type) return Distance
+      PRF               : in DW1000.Driver.PRF_Type) return Meters
    is
-      Initial_Distance : constant Distance := Distance (Measured_Distance);
+      Initial_Distance : constant Meters := Meters (Measured_Distance);
 
       Correction : Correction_Distance;
       PRF_Offset : Correction_Distance;
 
-      Result     : Distance;
+      Result     : Meters;
 
    begin
 
@@ -727,11 +741,7 @@ is
          --  Positive correction
          Correction := PRF_Offset - Correction;
 
-         if Initial_Distance <= Distance'Last - Correction then
-            Result := Initial_Distance + Correction;
-         else
-            Result := Distance'Last;
-         end if;
+         Result := Initial_Distance + Correction;
       end if;
 
       return Result;

--- a/src/dw1000-ranging.ads
+++ b/src/dw1000-ranging.ads
@@ -56,10 +56,6 @@ is
    --  (PRF) that was used to perform the measurement. This bias must be removed
    --  for a more accurate ranging measurement.
 
-   function To_Distance (Time_Of_Flight : in System_Time_Span) return Meters
-     with Global => null;
-   --  Calculate the distance based on the specified time of flight in seconds.
-
    function Remove_Ranging_Bias
      (Measured_Distance : in Biased_Distance;
       Channel           : in DW1000.Driver.Channel_Number;

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -187,7 +187,6 @@ is
 
       N   : Numerator_Range;
       D   : Denominator_Range;
-      Div : Division_Result_Range;
       R   : Long_Float;
       A   : Long_Float;
    begin
@@ -221,8 +220,7 @@ is
          D := 1.0;
       end if;
 
-      Div := N / D;
-      R := Log10 (Div);
+      R := Log10 (N / D);
 
       --  The values in this assumption were generated using Wolfram|Alpha
       --  based on the range of the Division_Result_Range subtype.

--- a/src/dw1000-system_time.adb
+++ b/src/dw1000-system_time.adb
@@ -38,59 +38,6 @@ is
       end if;
    end System_Time_Offset;
 
-
-   function To_Fine_System_Time (Bits : in Bits_40) return Fine_System_Time
-     with SPARK_Mode => Off
-   --  SPARK mode is disabled as a workaround because GNATprove does not
-   --  support an operation mixing two different fixed-point types.
-   is
-      type Fixed_40 is delta 1.0 range 0.0 .. 2.0**40 - 1.0
-        with Size => 40,
-        Small => 1.0;
-      --  Type big enough to hold all possible values of Bits_40.
-      --
-      --  Normally, values of Bits_40 cannot be multiplied with fixed point
-      --  types, however, casting a Bits_40 value to Fixed_40 then permits such
-      --  an operation between Fixed_40 and the other fixed point type
-      --  (e.g. System_Time).
-
-   begin
-      return Fine_System_Time (Fixed_40 (Bits) * Fine_System_Time'Delta);
-   end To_Fine_System_Time;
-
-
-   function To_Coarse_System_Time (Bits : in Bits_40) return Coarse_System_Time
-     with SPARK_Mode => Off
-   --  SPARK mode is disabled as a workaround because GNATprove does not
-   --  support an operation mixing two different fixed-point types.
-   is
-      type Fixed_31 is delta 1.0 range 0.0 .. 2.0**31 - 1.0
-        with Size => 31,
-        Small => 1.0;
-
-      MSB : constant Fixed_31 := Fixed_31 (Bits / 2**9);
-      --  The DW1000 ignores the 9 low order bits of the timestamp; they are
-      --  set to 0.
-
-   begin
-      return Coarse_System_Time (MSB * Coarse_System_Time'Delta);
-   end To_Coarse_System_Time;
-
-
-   function To_Antenna_Delay_Time (Bits : in Bits_16)
-                                   return Antenna_Delay_Time
-     with SPARK_Mode => Off
-   --  SPARK mode is disabled as a workaround because GNATprove does not
-   --  support an operation mixing two different fixed-point types.
-   is
-      type Fixed_16 is delta 1.0 range 0.0 .. 2.0**16 - 1.0
-        with Size => 16,
-        Small => 1.0;
-   begin
-      return Antenna_Delay_Time (Fixed_16 (Bits) * Fine_System_Time'Delta);
-   end To_Antenna_Delay_Time;
-
-
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Fine_System_Time)
                             return System_Time_Span
@@ -104,49 +51,5 @@ is
                                     End_Time);
       end if;
    end Calculate_Span;
-
-
-   package body Lemmas
-   with SPARK_Mode => On
-   is
-
-      function Bits_40_Fine_Conv_Inverse return Boolean
-      is
-      begin
-         pragma Assume ((for all X in Bits_40'Range =>
-                           (X = To_Bits_40 (To_Fine_System_Time (X)))),
-                        "property is proved with an exhaustive unit test");
-         return True;
-      end Bits_40_Fine_Conv_Inverse;
-
-
-      function Bits_40_Coarse_Conv_Inverse return Boolean
-      is
-      begin
-         pragma Assume ((for all X in Bits_40'Range =>
-                           (X = To_Bits_40 (To_Coarse_System_Time (X)))),
-                        "property is proved with an exhaustive unit test");
-         return True;
-      end Bits_40_Coarse_Conv_Inverse;
-
-
-      function To_Coarse_System_Time_Conv_Inverse (X : in Coarse_System_Time)
-                                                   return Boolean
-      is
-      begin
-         pragma Assume (X = To_Coarse_System_Time (To_Fine_System_Time (X)),
-                        "property is proved with an exhaustive unit test");
-         return True;
-      end To_Coarse_System_Time_Conv_Inverse;
-
-      function Bits_40_Conv_Transitive return Boolean
-      is
-      begin
-         pragma Assert (Bits_40_Coarse_Conv_Inverse);
-
-         return True;
-      end Bits_40_Conv_Transitive;
-
-   end Lemmas;
 
 end DW1000.System_Time;

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -80,11 +80,20 @@ package DW1000.System_Time
 with SPARK_Mode => On
 is
 
+   Chipping_Rate_Hz : constant := 499_200_000.0;
+   --  DW1000 system clocks are referenced to the 499.2 MHz chipping rate
+   --  defined in the IEEE 802.15.4-2011 standard.
+
+   System_Time_Clock_Hz : constant := Chipping_Rate_Hz * 128.0;
+   --  System time and time stamps are based on time units which are at
+   --  63.8976 GHz (499.2 MHz * 128). This yields a resolution of
+   --  approximately 15.65 picoseconds.
+
    type Fine_System_Time is
-   delta 1.0 / (499_200_000.0 * 128.0)
-   range 0.0 .. (2.0**40 - 1.0) / (499_200_000.0 * 128.0)
-     with Small => 1.0 / (499_200_000.0 * 128.0);
-   --  Type for representing the DW1000 fine grained system time in seconds,
+   delta 1.0 / System_Time_Clock_Hz
+   range 0.0 .. (2.0**40 - 1.0) / System_Time_Clock_Hz
+     with Small => 1.0 / System_Time_Clock_Hz;
+   --  Type for representing the DW1000 fine-grained system time in seconds,
    --  with a precision of at least 15.65 picoseconds.
    --
    --  The DW1000 uses Bits_40 to represent timestamp values (e.g. system time,
@@ -101,16 +110,16 @@ is
    --  circumstances.
 
    type Coarse_System_Time is
-   delta 512.0 / (499_200_000.0 * 128.0)
-   range 0.0 .. (2.0**40 - 1.0) / (499_200_000.0 * 128.0)
-     with Small => 512.0 / (499_200_000.0 * 128.0);
-   --  Type for representing the DW1000 coarse grained system time in seconds,
+   delta 512.0 / System_Time_Clock_Hz
+   range 0.0 .. (2.0**40 - 1.0) / System_Time_Clock_Hz
+     with Small => 512.0 / System_Time_Clock_Hz;
+   --  Type for representing the DW1000 coarsely-grained system time in seconds,
    --  with a precision of at least 8.013 nanoseconds.
    --
    --  The DW1000 uses Bits_40 to represent the system time counter and the
    --  delayed tx/rx times, but ignores the low 9 order bits giving an
    --  effective precision of 8.013 nanoseconds (512x less precise than the
-   --  fine grained system time used for the transmit and receive timestamps).
+   --  fine-grained system time used for the transmit and receive timestamps).
    --
    --  The Coarse_System_Time is used for the System Time Counter, and the
    --  delayed tx/rx times.
@@ -128,8 +137,8 @@ is
    --  Type to represent an antenna delay time.
 
    type Frame_Wait_Timeout_Time is
-   delta 512.0 / 499_200_000.0
-   range 0.0 .. ((2.0**16 - 1.0) * 512.0) / 499_200_000.0
+   delta 512.0 / Chipping_Rate_Hz
+   range 0.0 .. ((2.0**16 - 1.0) * 512.0) / Chipping_Rate_Hz
      with Small => 512.0 / 499_200_000.0;
    --  Type to represent the frame wait timeout.
    --

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -188,28 +188,11 @@ is
    --  time and rx/tx timestamp values. This function converts the 40-bit
    --  integer representation to the System_Time fixed-point representation.
 
-   function To_Fine_System_Time (Time : in Coarse_System_Time)
-                                 return Fine_System_Time is
-     (Fine_System_Time (Time))
-       with Inline,
-       Global => null;
-   --  Convert Coarse_System_Time to the equivalent Fine_System_Time value.
-
    function To_Coarse_System_Time (Bits : in Bits_40)
                                    return Coarse_System_Time
      with Inline,
      Global => null;
    --  Convert a 40-bit register value to Coarse_System_Time.
-
-   function To_Coarse_System_Time (Time : in Fine_System_Time)
-                                   return Coarse_System_Time is
-      (Coarse_System_Time (Time))
-       with Inline,
-       Global => null;
-   --  Convert a fine system time to a coarse system time.
-   --
-   --  This function rounds down to the nearest multiple of (approx.) 8.013
-   --  nanoseconds.
 
    function To_System_Time_Span (Bits : in Bits_40) return System_Time_Span
    is (System_Time_Span (To_Fine_System_Time (Bits)))
@@ -242,7 +225,7 @@ is
    function System_Time_Offset (Time : in Coarse_System_Time;
                                 Span : in System_Time_Span)
                                 return Fine_System_Time
-   is (System_Time_Offset (To_Fine_System_Time (Time), Span));
+   is (System_Time_Offset (Fine_System_Time (Time), Span));
 
 
    function Calculate_Span (Start_Time : in Fine_System_Time;
@@ -257,8 +240,8 @@ is
    function Calculate_Span (Start_Time : in Coarse_System_Time;
                             End_Time   : in Coarse_System_Time)
                             return System_Time_Span
-   is (Calculate_Span (To_Fine_System_Time (Start_Time),
-                       To_Fine_System_Time (End_Time)));
+   is (Calculate_Span (Fine_System_Time (Start_Time),
+                       Fine_System_Time (End_Time)));
    --  Calculate the time span between two points in time.
    --
    --  Note that since the DW1000 system time wraps-around after about every
@@ -269,7 +252,7 @@ is
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Coarse_System_Time)
                             return System_Time_Span
-   is (Calculate_Span (Start_Time, To_Fine_System_Time (End_Time)));
+   is (Calculate_Span (Start_Time, Fine_System_Time (End_Time)));
    --  Calculate the time span between two points in time.
    --
    --  Note that since the DW1000 system time wraps-around after about every
@@ -280,7 +263,7 @@ is
    function Calculate_Span (Start_Time : in Coarse_System_Time;
                             End_Time   : in Fine_System_Time)
                             return System_Time_Span
-   is (Calculate_Span (To_Fine_System_Time (Start_Time), End_Time));
+   is (Calculate_Span (Fine_System_Time (Start_Time), End_Time));
    --  Calculate the time span between two points in time.
    --
    --  Note that since the DW1000 system time wraps-around after about every


### PR DESCRIPTION
This pull request makes the following contributions:
1. Refactor the conversion routines in `DW1000.System_Time` so that all code is in SPARK.
2. Replace the Long_Float calculations in `DW1000.Ranging` with fixed-point equivalents.
3. Replace the `Distance` fixed-point type with a `Meters` (single) floating-point type.

The current implementation of `DW1000.System_Time` hides certain conversion functions from SPARK, which is not ideal since: a) that code cannot be proved; and b) the definition of the conversion is not available to the prover to help with proofs that use the conversion routines. Therefore, they have been replaced with conversions that can be in 100% SPARK.

The implementation of the `DW1000.Double_Sided` and `DW1000.Single_Sided` packages make extensive use of `Long_Float` to perform the calculations. These have been replaced with fixed-point equivalents since double-width FPUs are not really available on typical microcontrollers, so must fall back to a software implementation which is slow and integer math should be faster.

Finally, the `Distance` fixed-point type is replaced with a single-precision floating point type to avoid issues converting between fixed-point types. See the description in commit e8f4593 for details.

