### PR TITLE
Fix 2 proof warnings.

### DIFF
--- a/bsp-examples/dwm1001/decadriver_config.ads
+++ b/bsp-examples/dwm1001/decadriver_config.ads
@@ -31,6 +31,10 @@ is
    DW1000_IRQ_Id : constant Ada.Interrupts.Interrupt_ID
      := Ada.Interrupts.Names.GPIOTE_Interrupt;
    --  The interrupt ID for the DW1000 IRQ line.
+   --
+   --  This must not be a reserved interrupt. Note that GNAT Ravenscar runtimes
+   --  from bb-runtimes never have reserved interrupts, so any Interrupt_ID
+   --  is valid.
 
    Driver_Priority : constant System.Interrupt_Priority
      := System.Interrupt_Priority'Last;

--- a/src/decadriver.ads
+++ b/src/decadriver.ads
@@ -637,6 +637,10 @@ is
       --
       --  This performs functionality for packet reception and transmission.
 
+      pragma Annotate (GNATprove, False_Positive,
+                       "this interrupt might be reserved",
+                       "The interrupt is assumed to not be reserved");
+
       ---------------------------
       --  Configuration Items  --
       ---------------------------

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -107,14 +107,8 @@ is
       subtype Denominator_Range is Long_Float
       range 1.0 .. (2.0**16 - 1.0)**2;
 
-      subtype Division_Result_Range is Long_Float
-      range Numerator_Range'First / Denominator_Range'Last ..
-            Numerator_Range'Last  / Denominator_Range'First;
-
-
       N   : Numerator_Range;
       D   : Denominator_Range;
-      Div : Division_Result_Range;
       A   : Long_Float;
       R   : Long_Float;
    begin
@@ -146,8 +140,7 @@ is
          D := 1.0;
       end if;
 
-      Div := N / D;
-      R := Log10 (Div);
+      R := Log10 (N / D);
 
       --  The values in this assumption were generated using Wolfram|Alpha
       --  based on the range of the Division_Result_Range subtype.


### PR DESCRIPTION
This refactors a line in the Receive_Signal_Power function to help
GNATprove prove the precondition to Log10.

We also suppress a warning around the DW1000_IRQ's Attach_Interrupt
where a warning is issued about the possibility of a reserved
interrupt. Since there's no way to prove that it's not reserved,
or to somehow restrict the choice, we simply suppress the message
instead and assume that the interrupt is not reserved. A reserved
interrupt should be easy to spot since it will raise a Program_Error
when attaching it, which would be hard to miss.