### PR TITLE
WIP: Add types for DW1000 register fields.

### DIFF
--- a/bsp-examples/dwm1001/tx_power.ads
+++ b/bsp-examples/dwm1001/tx_power.ads
@@ -20,7 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
-with DW1000.Driver; use DW1000.Driver;
+with DW1000.Driver;         use DW1000.Driver;
+with DW1000.Register_Types; use DW1000.Register_Types;
 
 --  @summary
 --  Reference transmit power gain tables for both smart transmit power and
@@ -51,243 +52,168 @@ package Tx_Power
 with SPARK_Mode => On
 is
 
-   --  Values for the smart tx power mode.
-   Smart_Tx_Power_Table : constant Tx_Power_Config_Table
-       := (1 | 2 =>
-               (PRF_16MHz =>
+   --  Values for the smart tx power mode
+   Smart_Tx_Power_Table : constant Tx_Power_Config_Table :=
+     (1 | 2 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => True,
-                     Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_500us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 12.0),
-                     Boost_250us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 15.0),
-                     Boost_125us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 18.0)),
+                     Boost_Normal           => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_7_5_dB),
+                     Boost_500us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_10_dB),
+                     Boost_250us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_12_5_dB),
+                     Boost_125us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_15_dB)),
+
                 PRF_64MHz =>
                   (Smart_Tx_Power_Enabled => True,
-                   Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 9.0),
-                   Boost_500us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 12.0),
-                   Boost_250us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 15.0),
-                   Boost_125us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 18.0))),
-           3     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 15.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 15.0))),
-           4     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 15.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 18.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 15.0))),
-           5 | 6 =>  --  Ch6 not supported, so the power values doesn't matter
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 15.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 18.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 3.0,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 15.0))),
-           7     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 15.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 0.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 3.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 12.0)))
-          );
+                   Boost_Normal           => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_7_5_dB),
+                   Boost_500us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_10_dB),
+                   Boost_250us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_12_5_dB),
+                   Boost_125us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_15_dB))),
 
+      3 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_7_5_dB),
+                 Boost_500us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_250us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_12_5_dB),
+                 Boost_125us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_15_dB)),
 
-   --  Values for the manual tx power mode.
-   Manual_Tx_Power_Table : constant Tx_Power_Config_Table
-       := (1 | 2  =>
-               (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0)),
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_5_dB),
+               Boost_500us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_250us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_10_dB),
+               Boost_125us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_12_5_dB))),
+
+      4 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_500us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_12_5_dB),
+                 Boost_250us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_15_dB),
+                 Boost_125us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_15_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_5_dB),
+               Boost_500us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_250us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_10_dB),
+               Boost_125us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_12_5_dB))),
+
+      5 | 6 => (PRF_16MHz =>
+                    (Smart_Tx_Power_Enabled => True,
+                     Boost_Normal           => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_10_dB),
+                     Boost_500us            => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_12_5_dB),
+                     Boost_250us            => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_15_dB),
+                     Boost_125us            => (Fine_Gain   => 7.0,
+                                                Coarse_Gain => Gain_15_dB)),
+
                 PRF_64MHz =>
+                  (Smart_Tx_Power_Enabled => True,
+                   Boost_Normal           => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_5_dB),
+                   Boost_500us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_7_5_dB),
+                   Boost_250us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_10_dB),
+                   Boost_125us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_12_5_dB))),
+
+      7 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_5_dB),
+                 Boost_500us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_7_5_dB),
+                 Boost_250us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_125us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_12_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_0_dB),
+               Boost_500us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_2_5_dB),
+               Boost_250us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_125us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_10_dB))));
+
+   --  Values for the manual tx power mode
+   Manual_Tx_Power_Table : constant Tx_Power_Config_Table :=
+     (1 | 2 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 3.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 3.5,
-                                                Coarse_Gain         => 9.0))),
-           3      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 7.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 7.5,
-                                                Coarse_Gain         => 9.0)),
+                     Boost_SHR | Boost_PhR  => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_7_5_dB)),
+
                 PRF_64MHz =>
+                  (Smart_Tx_Power_Enabled => False,
+                   Boost_SHR | Boost_PHR  => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_7_5_dB))),
+
+      3 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_7_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_5_dB))),
+
+      4 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_10_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_5_dB))),
+
+      5 | 6 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 5.5,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 5.5,
-                                                Coarse_Gain         => 6.0))),
-           4      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 15.5,
-                                                Coarse_Gain         => 12.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 15.5,
-                                                Coarse_Gain         => 12.0)),
+                     Boost_SHR | Boost_PHR  => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_10_dB)),
+
                 PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 13.0,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 13.0,
-                                                Coarse_Gain         => 6.0))),
-           5 | 6  =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 4.0,
-                                                Coarse_Gain         => 12.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 4.0,
-                                                Coarse_Gain         => 12.0)),
-                PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 2.5,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 2.5,
-                                                Coarse_Gain         => 6.0))),
-           7      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 9.0,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 9.0,
-                                                Coarse_Gain         => 6.0)),
-                PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 8.5,
-                                                Coarse_Gain         => 0.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 8.5,
-                                                Coarse_Gain         => 0.0)))
-          );
+                  (Smart_Tx_Power_Enabled => False,
+                   Boost_SHR | Boost_PHR  => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_5_dB))),
+
+      7 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_0_dB))));
 
 end Tx_Power;

--- a/bsp-examples/evb1000/tx_power.ads
+++ b/bsp-examples/evb1000/tx_power.ads
@@ -51,243 +51,168 @@ package Tx_Power
 with SPARK_Mode => On
 is
 
-   --  Values for the smart tx power mode.
-   Smart_Tx_Power_Table : constant Tx_Power_Config_Table
-       := (1 | 2 =>
-               (PRF_16MHz =>
+   --  Values for the smart tx power mode
+   Smart_Tx_Power_Table : constant Tx_Power_Config_Table :=
+     (1 | 2 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => True,
-                     Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_500us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 12.0),
-                     Boost_250us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 15.0),
-                     Boost_125us            => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 18.0)),
+                     Boost_Normal           => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_7_5_dB),
+                     Boost_500us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_10_dB),
+                     Boost_250us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_12_5_dB),
+                     Boost_125us            => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_15_dB)),
+
                 PRF_64MHz =>
                   (Smart_Tx_Power_Enabled => True,
-                   Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 9.0),
-                   Boost_500us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 12.0),
-                   Boost_250us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 15.0),
-                   Boost_125us            => (Coarse_Gain_Enabled => True,
-                                              Fine_Gain           => 3.5,
-                                              Coarse_Gain         => 18.0))),
-           3     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 15.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 7.5,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 5.5,
-                                            Coarse_Gain         => 15.0))),
-           4     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 15.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 18.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 15.5,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 13.0,
-                                            Coarse_Gain         => 15.0))),
-           5 | 6 =>  --  Ch6 not supported, so the power values doesn't matter
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 15.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 4.0,
-                                            Coarse_Gain         => 18.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 3.0,
-                                            Coarse_Gain         => 18.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 2.5,
-                                            Coarse_Gain         => 15.0))),
-           7     =>
-             (PRF_16MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 6.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 9.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 12.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 9.0,
-                                            Coarse_Gain         => 15.0)),
-              PRF_64MHz =>
-                (Smart_Tx_Power_Enabled => True,
-                 Boost_Normal           => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 0.0),
-                 Boost_500us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 3.0),
-                 Boost_250us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 9.0),
-                 Boost_125us            => (Coarse_Gain_Enabled => True,
-                                            Fine_Gain           => 8.5,
-                                            Coarse_Gain         => 12.0)))
-          );
+                   Boost_Normal           => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_7_5_dB),
+                   Boost_500us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_10_dB),
+                   Boost_250us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_12_5_dB),
+                   Boost_125us            => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_15_dB))),
 
+      3 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_7_5_dB),
+                 Boost_500us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_250us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_12_5_dB),
+                 Boost_125us            => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_15_dB)),
 
-   --  Values for the manual tx power mode.
-   Manual_Tx_Power_Table : constant Tx_Power_Config_Table
-       := (1 | 2  =>
-               (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 10.5,
-                                                Coarse_Gain         => 9.0)),
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_5_dB),
+               Boost_500us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_250us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_10_dB),
+               Boost_125us            => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_12_5_dB))),
+
+      4 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_500us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_12_5_dB),
+                 Boost_250us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_15_dB),
+                 Boost_125us            => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_15_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_5_dB),
+               Boost_500us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_250us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_10_dB),
+               Boost_125us            => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_12_5_dB))),
+
+      5 | 6 => (PRF_16MHz =>
+                    (Smart_Tx_Power_Enabled => True,
+                     Boost_Normal           => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_10_dB),
+                     Boost_500us            => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_12_5_dB),
+                     Boost_250us            => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_15_dB),
+                     Boost_125us            => (Fine_Gain   => 7.0,
+                                                Coarse_Gain => Gain_15_dB)),
+
                 PRF_64MHz =>
+                  (Smart_Tx_Power_Enabled => True,
+                   Boost_Normal           => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_5_dB),
+                   Boost_500us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_7_5_dB),
+                   Boost_250us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_10_dB),
+                   Boost_125us            => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_12_5_dB))),
+
+      7 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => True,
+                 Boost_Normal           => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_5_dB),
+                 Boost_500us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_7_5_dB),
+                 Boost_250us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_10_dB),
+                 Boost_125us            => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_12_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => True,
+               Boost_Normal           => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_0_dB),
+               Boost_500us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_2_5_dB),
+               Boost_250us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_7_5_dB),
+               Boost_125us            => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_10_dB))));
+
+   --  Values for the manual tx power mode
+   Manual_Tx_Power_Table : constant Tx_Power_Config_Table :=
+     (1 | 2 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 3.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 3.5,
-                                                Coarse_Gain         => 9.0))),
-           3      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 7.5,
-                                                Coarse_Gain         => 9.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 7.5,
-                                                Coarse_Gain         => 9.0)),
+                     Boost_SHR | Boost_PhR  => (Fine_Gain   => 10.5,
+                                                Coarse_Gain => Gain_7_5_dB)),
+
                 PRF_64MHz =>
+                  (Smart_Tx_Power_Enabled => False,
+                   Boost_SHR | Boost_PHR  => (Fine_Gain   => 3.5,
+                                              Coarse_Gain => Gain_7_5_dB))),
+
+      3 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 7.5,
+                                            Coarse_Gain => Gain_7_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 5.5,
+                                          Coarse_Gain => Gain_5_dB))),
+
+      4 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 15.5,
+                                            Coarse_Gain => Gain_10_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 13.0,
+                                          Coarse_Gain => Gain_5_dB))),
+
+      5 | 6 => (PRF_16MHz =>
                     (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 5.5,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 5.5,
-                                                Coarse_Gain         => 6.0))),
-           4      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 15.5,
-                                                Coarse_Gain         => 12.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 15.5,
-                                                Coarse_Gain         => 12.0)),
+                     Boost_SHR | Boost_PHR  => (Fine_Gain   => 4.0,
+                                                Coarse_Gain => Gain_10_dB)),
+
                 PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 13.0,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 13.0,
-                                                Coarse_Gain         => 6.0))),
-           5 | 6  =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 4.0,
-                                                Coarse_Gain         => 12.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 4.0,
-                                                Coarse_Gain         => 12.0)),
-                PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 2.5,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 2.5,
-                                                Coarse_Gain         => 6.0))),
-           7      =>
-             (PRF_16MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 9.0,
-                                                Coarse_Gain         => 6.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 9.0,
-                                                Coarse_Gain         => 6.0)),
-                PRF_64MHz =>
-                    (Smart_Tx_Power_Enabled => False,
-                     Boost_SHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 8.5,
-                                                Coarse_Gain         => 0.0),
-                     Boost_PHR              => (Coarse_Gain_Enabled => True,
-                                                Fine_Gain           => 8.5,
-                                                Coarse_Gain         => 0.0)))
-          );
+                  (Smart_Tx_Power_Enabled => False,
+                   Boost_SHR | Boost_PHR  => (Fine_Gain   => 2.5,
+                                              Coarse_Gain => Gain_5_dB))),
+
+      7 => (PRF_16MHz =>
+                (Smart_Tx_Power_Enabled => False,
+                 Boost_SHR | Boost_PHR  => (Fine_Gain   => 9.0,
+                                            Coarse_Gain => Gain_5_dB)),
+
+            PRF_64MHz =>
+              (Smart_Tx_Power_Enabled => False,
+               Boost_SHR | Boost_PHR  => (Fine_Gain   => 8.5,
+                                          Coarse_Gain => Gain_0_dB))));
 
 end Tx_Power;

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -14,4 +14,6 @@ gprinstall -P temp/BSPs/ravenscar_full_nrf52832.gpr -p -f
 cd ..
 
 # Build all .gpr files in the examples directory
-find examples -regex ".*\.gpr$" -exec gprbuild -p -P {} -j0 -f -XBSP=DWM1001 \;
+gprbuild -p -P examples/transmit/transmit_example.gpr -j0 -f -XBSP=DWM1001
+gprbuild -p -P examples/receive/receive_example.gpr -j0 -f -XBSP=DWM1001
+gprbuild -p -P examples/echo/echo_example.gpr -j0 -f -XBSP=DWM1001

--- a/ci/proof.sh
+++ b/ci/proof.sh
@@ -14,4 +14,6 @@ gprinstall -P temp/BSPs/ravenscar_full_nrf52832.gpr -p -f
 cd ..
 
 # Prove all .gpr files in the examples directory
-find examples -regex ".*\.gpr$" -exec gnatprove -P {} --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001 \;
+gnatprove -P examples/transmit/transmit_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001
+gnatprove -P examples/receive/receive_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001
+gnatprove -P examples/echo/echo_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001

--- a/ci/proof.sh
+++ b/ci/proof.sh
@@ -14,6 +14,6 @@ gprinstall -P temp/BSPs/ravenscar_full_nrf52832.gpr -p -f
 cd ..
 
 # Prove all .gpr files in the examples directory
-gnatprove -P examples/transmit/transmit_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001
-gnatprove -P examples/receive/receive_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001
-gnatprove -P examples/echo/echo_example.gpr --mode=all --level=3 -j0 --checks-as-errors -XBSP=DWM1001
+gnatprove -P examples/transmit/transmit_example.gpr --mode=all --level=2 -j0 --checks-as-errors -XBSP=DWM1001
+gnatprove -P examples/receive/receive_example.gpr --mode=all --level=2 -j0 --checks-as-errors -XBSP=DWM1001
+gnatprove -P examples/echo/echo_example.gpr --mode=all --level=2 -j0 --checks-as-errors -XBSP=DWM1001

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -48,7 +48,7 @@ is
          RX_TTCKI_Reg     => (RXTTCKI => 0),
          RX_TTCKO_Reg     => (RXTOFS     => 0,
                               RSMPDEL    => 0,
-                              RCPHASE    => 0,
+                              RCPHASE    => 0.0,
                               Reserved_1 => 0,
                               Reserved_2 => 0),
          SFD_LENGTH       => 64,

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -224,12 +224,12 @@ is
 
          --  Configure IRQs
          DW1000.Registers.SYS_MASK.Read (SYS_MASK_Reg);
-         SYS_MASK_Reg.MRXRFTO  := 1;
-         SYS_MASK_Reg.MRXSFDTO := 1;
-         SYS_MASK_Reg.MRXPHE   := 1;
-         SYS_MASK_Reg.MRXRFSL  := 1;
-         SYS_MASK_Reg.MRXDFR   := 1; --  Always detect frame received
-         SYS_MASK_Reg.MTXFRS   := 1; --  Always detect frame sent
+         SYS_MASK_Reg.MRXRFTO  := Not_Masked;
+         SYS_MASK_Reg.MRXSFDTO := Not_Masked;
+         SYS_MASK_Reg.MRXPHE   := Not_Masked;
+         SYS_MASK_Reg.MRXRFSL  := Not_Masked;
+         SYS_MASK_Reg.MRXDFR   := Not_Masked; --  Always detect frame received
+         SYS_MASK_Reg.MTXFRS   := Not_Masked; --  Always detect frame sent
          DW1000.Registers.SYS_MASK.Write (SYS_MASK_Reg);
 
          Detect_Frame_Timeout := True;

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -285,14 +285,22 @@ is
          --  Configure the channel, Rx PRF, non-std SFD, and preamble codes
          DW1000.Registers.CHAN_CTRL.Write
            (DW1000.Register_Types.CHAN_CTRL_Type'
-              (TX_CHAN  => Bits_4 (Config.Channel),
-               RX_CHAN  => Bits_4 (Config.Channel),
-               DWSFD    => (if Config.Use_Nonstandard_SFD then 1 else 0),
-               RXPRF    => (if Config.PRF = PRF_16MHz then 2#01# else 2#10#),
-               TNSSFD   => (if Config.Use_Nonstandard_SFD then 1 else 0),
-               RNSSFD   => (if Config.Use_Nonstandard_SFD then 1 else 0),
-               TX_PCODE => Bits_5 (Config.Tx_Preamble_Code),
-               RX_PCODE => Bits_5 (Config.Rx_Preamble_Code),
+              (TX_CHAN  => CHAN_CTRL_Channel_Field (Config.Channel),
+               RX_CHAN  => CHAN_CTRL_Channel_Field (Config.Channel),
+               DWSFD    => (if Config.Use_Nonstandard_SFD
+                            then Enabled
+                            else Disabled),
+               RXPRF    => (if Config.PRF = PRF_16MHz
+                            then PRF_16MHz
+                            else PRF_64MHz),
+               TNSSFD   => (if Config.Use_Nonstandard_SFD
+                            then Enabled
+                            else Disabled),
+               RNSSFD   => (if Config.Use_Nonstandard_SFD
+                            then Enabled
+                            else Disabled),
+               TX_PCODE => CHAN_CTRL_PCODE_Field (Config.Tx_Preamble_Code),
+               RX_PCODE => CHAN_CTRL_PCODE_Field (Config.Rx_Preamble_Code),
                Reserved => 0));
 
          --  Set the Tx frame control (transmit data rate, PRF, ranging bit)
@@ -602,7 +610,7 @@ is
                begin
                   DW1000.Registers.CHAN_CTRL.Read (CHAN_CTRL_Reg);
                   Frame_Queue (Next_Idx).Frame_Info.Non_Standard_SFD
-                    := CHAN_CTRL_Reg.DWSFD = 1;
+                    := CHAN_CTRL_Reg.DWSFD = Enabled;
                end;
             end if;
 

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -35,10 +35,7 @@ is
    Default_SFD_Timeout : constant DW1000.Driver.SFD_Timeout_Number := 16#1041#;
 
    Null_Frame_Info : constant Frame_Info_Type
-     := (RX_TIME_Reg      => (RX_STAMP => 0,
-                              FP_INDEX => 0,
-                              FP_AMPL1 => 0,
-                              RX_RAWST => 0),
+     := (RX_TIME_Reg      => (others   => <>),
          RX_FINFO_Reg     => (others   => <>),
          RX_FQUAL_Reg     => (STD_NOISE => 0,
                               FP_AMPL2  => 0,
@@ -62,7 +59,7 @@ is
                                return Fine_System_Time
    is
    begin
-      return To_Fine_System_Time (Frame_Info.RX_TIME_Reg.RX_STAMP);
+      return Frame_Info.RX_TIME_Reg.RX_STAMP;
    end Receive_Timestamp;
 
    ----------------------------

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -201,7 +201,7 @@ is
          else
             -- Should disable LDERUN bit, since the LDE isn't loaded.
             DW1000.Registers.PMSC_CTRL1.Read (PMSC_CTRL1_Reg);
-            PMSC_CTRL1_Reg.LDERUNE := 0;
+            PMSC_CTRL1_Reg.LDERUNE := Disabled;
             DW1000.Registers.PMSC_CTRL1.Write (PMSC_CTRL1_Reg);
          end if;
 

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -312,14 +312,17 @@ is
               (TFLEN    => 0,
                TFLE     => 0,
                R        => 0,
-               TXBR     => Bits_2 (Data_Rates'Pos (Config.Data_Rate)),
-               TR       => 1,
-               TXPRF    => (if Config.PRF = PRF_16MHz then 2#01# else 2#10#),
+               TXBR     => (case Config.Data_Rate is
+                               when Data_Rate_110k => Data_Rate_110K,
+                               when Data_Rate_850k => Data_Rate_850K,
+                               when Data_Rate_6M8 => Data_Rate_6M8),
+               TR       => Enabled,
+               TXPRF    => (if Config.PRF = PRF_16MHz then PRF_16MHz else PRF_64MHz),
                TXPSR    =>
                  (case Config.Tx_Preamble_Length is
-                     when PLEN_64 | PLEN_128 | PLEN_256 | PLEN_512 => 2#01#,
-                     when PLEN_1024 | PLEN_1536 | PLEN_2048        => 2#10#,
-                     when others                                   => 2#11#),
+                     when PLEN_64 | PLEN_128 | PLEN_256 | PLEN_512 => PLEN_64,
+                     when PLEN_1024 | PLEN_1536 | PLEN_2048        => PLEN_1024,
+                     when others                                   => PLEN_4096),
                PE       =>
                  (case Config.Tx_Preamble_Length is
                      when PLEN_64 | PLEN_1024 | PLEN_4096 => 2#00#,

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -190,7 +190,7 @@ is
 
          if Load_XTAL_Trim then
             DW1000.Driver.Read_OTP (OTP_ADDR_XTAL_TRIM, Word);
-            XTAL_Trim := Bits_5 (Word and 2#1_1111#);
+            XTAL_Trim := FS_XTALT_Field (Word and 2#1_1111#);
          else
             XTAL_Trim := 2#1_0000#; -- Set to midpoint
          end if;

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -252,14 +252,15 @@ is
 
          --  110 kbps data rate has special handling
          if Config.Data_Rate = DW1000.Driver.Data_Rate_110k then
-            SYS_CFG_Reg.RXM110K := 1;
+            SYS_CFG_Reg.RXM110K := SFD_110K;
          else
-            SYS_CFG_Reg.RXM110K := 0;
+            SYS_CFG_Reg.RXM110K := SFD_850K_6M8;
          end if;
 
          --  Set physical header mode (standard or extended frames)
          Long_Frames := Config.PHR_Mode = Extended_Frames;
-         SYS_CFG_Reg.PHR_MODE := Bits_2 (Physical_Header_Modes'Pos (Config.PHR_Mode));
+         SYS_CFG_Reg.PHR_MODE := SYS_CFG_PHR_MODE_Field'Val
+           (Physical_Header_Modes'Pos (Config.PHR_Mode));
 
          DW1000.Registers.SYS_CFG.Write (SYS_CFG_Reg);
 

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -39,15 +39,7 @@ is
                               FP_INDEX => 0,
                               FP_AMPL1 => 0,
                               RX_RAWST => 0),
-         RX_FINFO_Reg     => (RXFLEN   => 0,
-                              RXFLE    => 0,
-                              RXNSPL   => 0,
-                              RXBR     => 0,
-                              RNG      => 0,
-                              RXPRF    => 0,
-                              RXPSR    => 0,
-                              RXPACC   => 0,
-                              Reserved => 0),
+         RX_FINFO_Reg     => (others   => <>),
          RX_FQUAL_Reg     => (STD_NOISE => 0,
                               FP_AMPL2  => 0,
                               FP_AMPL3  => 0,
@@ -80,14 +72,14 @@ is
    function Receive_Signal_Power (Frame_Info : in Frame_Info_Type)
                                   return Float
    is
-      RXBR       : Bits_2;
+      RXBR       : RX_FINFO_RXBR_Field;
       SFD_LENGTH : Bits_8;
-      RXPACC     : Bits_12;
+      RXPACC     : RX_FINFO_RXPACC_Field;
 
    begin
       RXBR := Frame_Info.RX_FINFO_Reg.RXBR;
-      if RXBR = 2#11# then --  Detect reserved value
-         RXBR := 2#10#;    --  default to 6.8 Mbps
+      if RXBR = Reserved then --  Detect reserved value
+         RXBR := Data_Rate_6M8;    --  default to 6.8 Mbps
       end if;
 
       SFD_LENGTH := Frame_Info.SFD_LENGTH;
@@ -103,7 +95,7 @@ is
          Non_Standard_SFD => Frame_Info.Non_Standard_SFD);
 
       return Receive_Signal_Power
-        (Use_16MHz_PRF => Frame_Info.RX_FINFO_Reg.RXPRF = 2#10#,
+        (Use_16MHz_PRF => Frame_Info.RX_FINFO_Reg.RXPRF = PRF_16MHz,
          RXPACC        => RXPACC,
          CIR_PWR       => Frame_Info.RX_FQUAL_Reg.CIR_PWR);
    end Receive_Signal_Power;
@@ -115,13 +107,13 @@ is
    function First_Path_Signal_Power (Frame_Info : in Frame_Info_Type)
                                      return Float
    is
-      RXBR       : Bits_2;
+      RXBR       : RX_FINFO_RXBR_Field;
       SFD_LENGTH : Bits_8;
-      RXPACC     : Bits_12;
+      RXPACC     : RX_FINFO_RXPACC_Field;
    begin
       RXBR := Frame_Info.RX_FINFO_Reg.RXBR;
-      if RXBR = 2#11# then --  Detect reserved value
-         RXBR := 2#10#; --  default to 6.8 Mbps
+      if RXBR = Reserved then --  Detect reserved value
+         RXBR := Data_Rate_6M8; --  default to 6.8 Mbps
       end if;
 
       SFD_LENGTH := Frame_Info.SFD_LENGTH;
@@ -137,7 +129,7 @@ is
          Non_Standard_SFD => Frame_Info.Non_Standard_SFD);
 
       return First_Path_Signal_Power
-        (Use_16MHz_PRF => Frame_Info.RX_FINFO_Reg.RXPRF = 2#10#,
+        (Use_16MHz_PRF => Frame_Info.RX_FINFO_Reg.RXPRF = PRF_16MHz,
          F1            => Frame_Info.RX_TIME_Reg.FP_AMPL1,
          F2            => Frame_Info.RX_FQUAL_Reg.FP_AMPL2,
          F3            => Frame_Info.RX_FQUAL_Reg.FP_AMPL3,

--- a/src/decadriver.ads
+++ b/src/decadriver.ads
@@ -655,10 +655,8 @@ is
       Long_Frames : Boolean := False;
 
       SYS_CFG_Reg : SYS_CFG_Type := SYS_CFG_Type'
-        (Reserved_1 => 0,
-         Reserved_2 => 0,
-         PHR_MODE   => 0,
-         others     => 0);
+        (PHR_MODE   => Standard_Frames_Mode,
+         others     => <>);
 
       Use_OTP_XTAL_Trim     : Boolean := False;
       Use_OTP_Antenna_Delay : Boolean := False;

--- a/src/decadriver.ads
+++ b/src/decadriver.ads
@@ -650,7 +650,7 @@ is
 
       Antenna_Delay_PRF_64 : Antenna_Delay_Time := 0.0;
       Antenna_Delay_PRF_16 : Antenna_Delay_Time := 0.0;
-      XTAL_Trim            : Bits_5  := 2#1_0000#;
+      XTAL_Trim            : FS_XTALT_Field     := 2#1_0000#;
 
       Long_Frames : Boolean := False;
 

--- a/src/dw1000-constants.ads
+++ b/src/dw1000-constants.ads
@@ -20,7 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
-with DW1000.Types; use DW1000.Types;
+with DW1000.Types;          use DW1000.Types;
+with DW1000.Register_Types; use DW1000.Register_Types;
 
 package DW1000.Constants
 with SPARK_Mode => On
@@ -28,24 +29,24 @@ is
 
    ----------------------------------------------------------------------------
    --  OTP memory word addresses
-   OTP_ADDR_EUID                : constant Bits_11 := 16#00#;
-   OTP_ADDR_LDOTUNE_CAL         : constant Bits_11 := 16#04#;
-   OTP_ADDR_CHIP_ID             : constant Bits_11 := 16#06#;
-   OTP_ADDR_LOT_ID              : constant Bits_11 := 16#07#;
-   OTP_ADDR_CH1_TX_POWER_PRF_16 : constant Bits_11 := 16#10#;
-   OTP_ADDR_CH1_TX_POWER_PRF_64 : constant Bits_11 := 16#11#;
-   OTP_ADDR_CH2_TX_POWER_PRF_16 : constant Bits_11 := 16#12#;
-   OTP_ADDR_CH2_TX_POWER_PRF_64 : constant Bits_11 := 16#13#;
-   OTP_ADDR_CH3_TX_POWER_PRF_16 : constant Bits_11 := 16#14#;
-   OTP_ADDR_CH3_TX_POWER_PRF_64 : constant Bits_11 := 16#15#;
-   OTP_ADDR_CH4_TX_POWER_PRF_16 : constant Bits_11 := 16#16#;
-   OTP_ADDR_CH4_TX_POWER_PRF_64 : constant Bits_11 := 16#17#;
-   OTP_ADDR_CH5_TX_POWER_PRF_16 : constant Bits_11 := 16#18#;
-   OTP_ADDR_CH5_TX_POWER_PRF_64 : constant Bits_11 := 16#19#;
-   OTP_ADDR_CH7_TX_POWER_PRF_16 : constant Bits_11 := 16#1A#;
-   OTP_ADDR_CH7_TX_POWER_PRF_64 : constant Bits_11 := 16#1B#;
-   OTP_ADDR_ANTENNA_DELAY       : constant Bits_11 := 16#1C#;
-   OTP_ADDR_XTAL_TRIM           : constant Bits_11 := 16#E0#;
+   OTP_ADDR_EUID                : constant OTP_ADDR_Field := 16#00#;
+   OTP_ADDR_LDOTUNE_CAL         : constant OTP_ADDR_Field := 16#04#;
+   OTP_ADDR_CHIP_ID             : constant OTP_ADDR_Field := 16#06#;
+   OTP_ADDR_LOT_ID              : constant OTP_ADDR_Field := 16#07#;
+   OTP_ADDR_CH1_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#10#;
+   OTP_ADDR_CH1_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#11#;
+   OTP_ADDR_CH2_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#12#;
+   OTP_ADDR_CH2_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#13#;
+   OTP_ADDR_CH3_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#14#;
+   OTP_ADDR_CH3_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#15#;
+   OTP_ADDR_CH4_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#16#;
+   OTP_ADDR_CH4_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#17#;
+   OTP_ADDR_CH5_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#18#;
+   OTP_ADDR_CH5_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#19#;
+   OTP_ADDR_CH7_TX_POWER_PRF_16 : constant OTP_ADDR_Field := 16#1A#;
+   OTP_ADDR_CH7_TX_POWER_PRF_64 : constant OTP_ADDR_Field := 16#1B#;
+   OTP_ADDR_ANTENNA_DELAY       : constant OTP_ADDR_Field := 16#1C#;
+   OTP_ADDR_XTAL_TRIM           : constant OTP_ADDR_Field := 16#E0#;
 
    ----------------------------------------------------------------------------
    --  Buffer lengths

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -595,26 +595,29 @@ is
    is
    begin
       TX_FCTRL.Write
-        ((TFLEN    => Bits_7 (Frame_Length mod 128),
-          TFLE     => Bits_3 (Frame_Length / 128),
+        ((TFLEN    => TX_FCTRL_TFLEN_Field (Frame_Length mod 128),
+          TFLE     => TX_FCTRL_TFLE_Field (Frame_Length / 128),
           R        => 0,
-          TXBR     => Bits_2 (Data_Rates'Pos (Tx_Data_Rate)),
-          TR       => (if Ranging then 1 else 0),
+          TXBR     => (case Tx_Data_Rate is
+                          when Data_Rate_110k => Data_Rate_110K,
+                          when Data_Rate_850k => Data_Rate_850K,
+                          when Data_Rate_6M8  => Data_Rate_6M8),
+          TR       => (if Ranging then Enabled else Disabled),
           TXPRF    => (if Tx_PRF = PRF_16MHz
-                       then 2#01# else 2#10#),
+                       then PRF_16MHz else PRF_64MHz),
           TXPSR    =>
              (case Preamble_Length is
-                 when PLEN_64 | PLEN_128 | PLEN_256 | PLEN_512 => 2#01#,
-                 when PLEN_1024 | PLEN_1536 | PLEN_2048        => 2#10#,
-                 when others                                   => 2#11#),
+                 when PLEN_64 | PLEN_128 | PLEN_256 | PLEN_512 => PLEN_64,
+                 when PLEN_1024 | PLEN_1536 | PLEN_2048        => PLEN_1024,
+                 when others                                   => PLEN_4096),
           PE       =>
             (case Preamble_Length is
                 when PLEN_64 | PLEN_1024 | PLEN_4096 => 2#00#,
                 when PLEN_128 | PLEN_1536            => 2#01#,
                 when PLEN_256 | PLEN_2048            => 2#10#,
                 when others                          => 2#11#),
-          TXBOFFS  => Bits_10 (Tx_Buffer_Offset),
-          IFSDELAY => Bits_8 (Inter_Frame_Spacing)));
+          TXBOFFS  => TX_FCTRL_TXBOFFS_Field (Tx_Buffer_Offset),
+          IFSDELAY => TX_FCTRL_IFSDELAY_Field (Inter_Frame_Spacing)));
    end Configure_TX_FCTRL;
 
    procedure Configure_CHAN_CTRL
@@ -983,9 +986,9 @@ is
 
    begin
       TX_FCTRL.Read (TX_FCTRL_Reg);
-      TX_FCTRL_Reg.TFLEN   := Types.Bits_7 (Length mod 2**7);
-      TX_FCTRL_Reg.TFLE    := Types.Bits_3 (Length / 2**7);
-      TX_FCTRL_Reg.TXBOFFS := Types.Bits_10 (Offset);
+      TX_FCTRL_Reg.TFLEN   := TX_FCTRL_TFLEN_Field (Length mod 2**7);
+      TX_FCTRL_Reg.TFLE    := TX_FCTRL_TFLE_Field (Length / 2**7);
+      TX_FCTRL_Reg.TXBOFFS := TX_FCTRL_TXBOFFS_Field (Offset);
       TX_FCTRL.Write (TX_FCTRL_Reg);
 
    end Set_Tx_Frame_Length;

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -37,36 +37,36 @@ is
          PMULT => 3);
 
    -- These values for LDE_CFG2 are given by the user manual
-   LDE_CFG2_Values : constant array (PRF_Type) of Types.Bits_16
-     := (PRF_16MHz => 16#1607#,
-         PRF_64MHz => 16#0607#);
+   LDE_CFG2_Values : constant array (PRF_Type) of LDE_CFG2_Field
+     := (PRF_16MHz => LDE_CFG2_16MHz,
+         PRF_64MHz => LDE_CFG2_64MHz);
 
    LDE_Replica_Coeffs : constant
-     array (Preamble_Code_Number) of Bits_16
-       := (1  => Bits_16 (0.35 * 2**16),
-           2  => Bits_16 (0.35 * 2**16),
-           3  => Bits_16 (0.32 * 2**16),
-           4  => Bits_16 (0.26 * 2**16),
-           5  => Bits_16 (0.27 * 2**16),
-           6  => Bits_16 (0.18 * 2**16),
-           7  => Bits_16 (0.50 * 2**16),
-           8  => Bits_16 (0.32 * 2**16),
-           9  => Bits_16 (0.16 * 2**16),
-           10 => Bits_16 (0.20 * 2**16),
-           11 => Bits_16 (0.23 * 2**16),
-           12 => Bits_16 (0.24 * 2**16),
-           13 => Bits_16 (0.23 * 2**16),
-           14 => Bits_16 (0.21 * 2**16),
-           15 => Bits_16 (0.27 * 2**16),
-           16 => Bits_16 (0.21 * 2**16),
-           17 => Bits_16 (0.20 * 2**16),
-           18 => Bits_16 (0.21 * 2**16),
-           19 => Bits_16 (0.21 * 2**16),
-           20 => Bits_16 (0.28 * 2**16),
-           21 => Bits_16 (0.23 * 2**16),
-           22 => Bits_16 (0.22 * 2**16),
-           23 => Bits_16 (0.19 * 2**16),
-           24 => Bits_16 (0.22 * 2**16));
+     array (Preamble_Code_Number) of LDE_REPC_Field
+       := (1  => LDE_REPC_Field (0.35 * 2**16),
+           2  => LDE_REPC_Field (0.35 * 2**16),
+           3  => LDE_REPC_Field (0.32 * 2**16),
+           4  => LDE_REPC_Field (0.26 * 2**16),
+           5  => LDE_REPC_Field (0.27 * 2**16),
+           6  => LDE_REPC_Field (0.18 * 2**16),
+           7  => LDE_REPC_Field (0.50 * 2**16),
+           8  => LDE_REPC_Field (0.32 * 2**16),
+           9  => LDE_REPC_Field (0.16 * 2**16),
+           10 => LDE_REPC_Field (0.20 * 2**16),
+           11 => LDE_REPC_Field (0.23 * 2**16),
+           12 => LDE_REPC_Field (0.24 * 2**16),
+           13 => LDE_REPC_Field (0.23 * 2**16),
+           14 => LDE_REPC_Field (0.21 * 2**16),
+           15 => LDE_REPC_Field (0.27 * 2**16),
+           16 => LDE_REPC_Field (0.21 * 2**16),
+           17 => LDE_REPC_Field (0.20 * 2**16),
+           18 => LDE_REPC_Field (0.21 * 2**16),
+           19 => LDE_REPC_Field (0.21 * 2**16),
+           20 => LDE_REPC_Field (0.28 * 2**16),
+           21 => LDE_REPC_Field (0.23 * 2**16),
+           22 => LDE_REPC_Field (0.22 * 2**16),
+           23 => LDE_REPC_Field (0.19 * 2**16),
+           24 => LDE_REPC_Field (0.22 * 2**16));
 
    -- These values for FS_PLLCFG are given by the user manual
    FS_PLLCFG_Values : constant array (Positive range 1 .. 7) of FS_PLLCFG_Field
@@ -422,7 +422,7 @@ is
    begin
       LDE_RXANTD.Read (LDE_RXANTD_Reg);
 
-      Antenna_Delay := To_Antenna_Delay_Time (LDE_RXANTD_Reg.LDE_RXANTD);
+      Antenna_Delay := LDE_RXANTD_Reg.LDE_RXANTD;
    end Read_Rx_Antenna_Delay;
 
 
@@ -430,7 +430,7 @@ is
    procedure Write_Rx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
    is
    begin
-      LDE_RXANTD.Write ( (LDE_RXANTD => To_Bits_16 (Antenna_Delay)) );
+      LDE_RXANTD.Write ( (LDE_RXANTD => Antenna_Delay) );
    end Write_Rx_Antenna_Delay;
 
 
@@ -438,7 +438,7 @@ is
                             Rx_Preamble_Code : in Preamble_Code_Number;
                             Data_Rate        : in Data_Rates)
    is
-      REPC_Coeff : Bits_16;
+      REPC_Coeff : LDE_REPC_Field;
 
    begin
       LDE_CFG1.Write (LDE_CFG1_Value);

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1182,12 +1182,11 @@ is
    begin
       -- Temporarily disable all interrupts
       SYS_MASK.Read (SYS_MASK_Reg);
-      SYS_MASK.Write (SYS_MASK_Type'(Reserved_3 => 0,
-                                     others     => 0));
+      SYS_MASK.Write (SYS_MASK_Type'(others => <>));
 
       -- Disable Tx/Rx
-      SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF     => Transceiver_Off,
-                                     others     => <>));
+      SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF => Transceiver_Off,
+                                     others => <>));
 
       -- Force transceiver off; don't want to see any new events.
       SYS_STATUS.Write (SYS_STATUS_Type'(AAT        => 1,

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1131,7 +1131,7 @@ is
 
    begin
       TX_TIME.Read (TX_TIME_Reg);
-      Timestamp := To_Fine_System_Time (TX_TIME_Reg.TX_STAMP);
+      Timestamp := TX_TIME_Reg.TX_STAMP;
    end Read_Tx_Adjusted_Timestamp;
 
 
@@ -1141,7 +1141,7 @@ is
 
    begin
       TX_TIME.Read (TX_TIME_Reg);
-      Timestamp := To_Coarse_System_Time (TX_TIME_Reg.TX_RAWST);
+      Timestamp := TX_TIME_Reg.TX_RAWST;
    end Read_Tx_Raw_Timestamp;
 
 
@@ -1152,8 +1152,8 @@ is
 
    begin
       TX_TIME.Read (TX_TIME_Reg);
-      Adjusted := To_Fine_System_Time (TX_TIME_Reg.TX_STAMP);
-      Raw      := To_Coarse_System_Time (TX_TIME_Reg.TX_RAWST);
+      Adjusted := TX_TIME_Reg.TX_STAMP;
+      Raw      := TX_TIME_Reg.TX_RAWST;
    end Read_Tx_Timestamps;
 
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -149,15 +149,9 @@ is
         );
 
    -- These values for AGC_TUNE1 are given by the user manual
-   AGC_TUNE1_Values : constant array (PRF_Type) of Types.Bits_16
-     := (PRF_16MHz => 16#8870#,
-         PRF_64MHz => 16#889B#);
-
-   -- This value for AGC_TUNE2 is given by the user manual
-   AGC_TUNE2_Value : constant Types.Bits_32 := 16#2502A907#;
-
-   -- This value for AGC_TUNE3 is given by the user manual
-   AGC_TUNE3_Value : constant Types.Bits_16 := 16#0035#;
+   AGC_TUNE1_Values : constant array (PRF_Type) of AGC_TUNE1_Field
+     := (PRF_16MHz => AGC_TUNE1_PRF_16MHz,
+         PRF_64MHz => AGC_TUNE1_PRF_64MHz);
 
    -- These values for TC_PGDELAY are given by the user manual
    TC_PGDELAY_Values : constant array (Positive range 1 .. 7) of Bits_8

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -413,7 +413,7 @@ is
    begin
       TX_ANTD.Read (TX_ANTD_Reg);
 
-      Antenna_Delay := To_Antenna_Delay_Time (TX_ANTD_Reg.TX_ANTD);
+      Antenna_Delay := TX_ANTD_Reg.TX_ANTD;
    end Read_Tx_Antenna_Delay;
 
 
@@ -421,8 +421,7 @@ is
    procedure Write_Tx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
    is
    begin
-      TX_ANTD.Write
-        ( (TX_ANTD => To_Bits_16 (Antenna_Delay)) );
+      TX_ANTD.Write ( (TX_ANTD => Antenna_Delay) );
    end Write_Tx_Antenna_Delay;
 
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -630,15 +630,21 @@ is
       Rx_Preamble_Code        : in Preamble_Code_Number)
    is
    begin
-      CHAN_CTRL.Write ((TX_CHAN  => Bits_4 (Tx_Channel),
-                        RX_CHAN  => Bits_4 (Rx_Channel),
-                        DWSFD    => (if Use_DecaWave_SFD then 1 else 0),
+      CHAN_CTRL.Write ((TX_CHAN  => CHAN_CTRL_Channel_Field (Tx_Channel),
+                        RX_CHAN  => CHAN_CTRL_Channel_Field (Rx_Channel),
+                        DWSFD    => (if Use_DecaWave_SFD
+                                     then Enabled
+                                     else Disabled),
                         RXPRF    => (if Rx_PRF = PRF_16MHz
-                                     then 2#01# else 2#10#),
-                        TNSSFD   => (if Use_Tx_User_Defined_SFD then 1 else 0),
-                        RNSSFD   => (if Use_Rx_User_Defined_SFD then 1 else 0),
-                        TX_PCODE => Bits_5 (Tx_Preamble_Code),
-                        RX_PCODE => Bits_5 (Rx_Preamble_Code),
+                                     then PRF_16MHz else PRF_64MHz),
+                        TNSSFD   => (if Use_Tx_User_Defined_SFD
+                                     then Enabled
+                                     else Disabled),
+                        RNSSFD   => (if Use_Rx_User_Defined_SFD
+                                     then Enabled
+                                     else Disabled),
+                        TX_PCODE => CHAN_CTRL_PCODE_Field (Tx_Preamble_Code),
+                        RX_PCODE => CHAN_CTRL_PCODE_Field (Rx_Preamble_Code),
                         Reserved => 0));
    end Configure_CHAN_CTRL;
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1605,10 +1605,10 @@ is
    begin
       --  Configure LED GPIOs
       GPIO_MODE.Read (GPIO_MODE_Reg);
-      GPIO_MODE_Reg.MSGP0 := (if Rx_OK_LED_Enable then 1 else 0);
-      GPIO_MODE_Reg.MSGP1 := (if SFD_LED_Enable   then 1 else 0);
-      GPIO_MODE_Reg.MSGP2 := (if Rx_LED_Enable    then 1 else 0);
-      GPIO_MODE_Reg.MSGP3 := (if Tx_LED_Enable    then 1 else 0);
+      GPIO_MODE_Reg.MSGP0 := (if Rx_OK_LED_Enable then RXOKLED else GPIO0);
+      GPIO_MODE_Reg.MSGP1 := (if SFD_LED_Enable   then SFDLED  else GPIO1);
+      GPIO_MODE_Reg.MSGP2 := (if Rx_LED_Enable    then RXLED   else GPIO2);
+      GPIO_MODE_Reg.MSGP3 := (if Tx_LED_Enable    then TXLED   else GPIO3);
       GPIO_MODE.Write (GPIO_MODE_Reg);
 
       --  Enable LP oscillator to run from counter, turn on debounce clock

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1099,7 +1099,7 @@ is
 
    begin
       RX_TIME.Read (RX_TIME_Reg);
-      Timestamp := To_Fine_System_Time (RX_TIME_Reg.RX_STAMP);
+      Timestamp := RX_TIME_Reg.RX_STAMP;
    end Read_Rx_Adjusted_Timestamp;
 
 
@@ -1109,7 +1109,7 @@ is
 
    begin
       RX_TIME.Read (RX_TIME_Reg);
-      Timestamp := To_Coarse_System_Time (RX_TIME_Reg.RX_RAWST);
+      Timestamp := RX_TIME_Reg.RX_RAWST;
    end Read_Rx_Raw_Timestamp;
 
 
@@ -1120,8 +1120,8 @@ is
 
    begin
       RX_TIME.Read (RX_TIME_Reg);
-      Adjusted := To_Fine_System_Time (RX_TIME_Reg.RX_STAMP);
-      Raw      := To_Coarse_System_Time (RX_TIME_Reg.RX_RAWST);
+      Adjusted := RX_TIME_Reg.RX_STAMP;
+      Raw      := RX_TIME_Reg.RX_RAWST;
    end Read_Rx_Timestamps;
 
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -145,14 +145,14 @@ is
          PRF_64MHz => AGC_TUNE1_PRF_64MHz);
 
    -- These values for TC_PGDELAY are given by the user manual
-   TC_PGDELAY_Values : constant array (Positive range 1 .. 7) of Bits_8
-     := (1 => 16#C9#,
-         2 => 16#C2#,
-         3 => 16#C5#,
-         4 => 16#95#,
-         5 => 16#C0#,
+   TC_PGDELAY_Values : constant array (Positive range 1 .. 7) of TC_PGDELAY_Field
+     := (1 => TC_PGDELAY_Channel_1,
+         2 => TC_PGDELAY_Channel_2,
+         3 => TC_PGDELAY_Channel_3,
+         4 => TC_PGDELAY_Channel_4,
+         5 => TC_PGDELAY_Channel_5,
          6 => 0,      --  Channel 6 not in Channel_Number
-         7 => 16#93#);
+         7 => TC_PGDELAY_Channel_7);
 
    -- This value for non-standard SFD lengths are given by the user manual
    Non_Standard_SFD_Lengths : constant array (Data_Rates) of Types.Bits_8

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -24,6 +24,7 @@ with Ada.Unchecked_Conversion;
 with DW1000.Constants;       use DW1000.Constants;
 with DW1000.Registers;       use DW1000.Registers;
 with DW1000.Register_Driver;
+with DW1000.Register_Types;  use DW1000.Register_Types;
 
 
 package body DW1000.Driver
@@ -761,7 +762,9 @@ is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.FFEN := (if Enabled then 1 else 0);
+      SYS_CFG_Reg.FFEN := (if Enabled
+                           then Register_Types.Enabled
+                           else Register_Types.Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Frame_Filtering_Enabled;
 
@@ -770,7 +773,7 @@ is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_FCE := (if Enabled then 0 else 1);
+      SYS_CFG_Reg.DIS_FCE := (if Enabled then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_FCS_Check_Enabled;
 
@@ -786,14 +789,14 @@ is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.FFBC := (if Behave_As_Coordinator then 1 else 0);
-      SYS_CFG_Reg.FFAB := (if Allow_Beacon_Frame    then 1 else 0);
-      SYS_CFG_Reg.FFAD := (if Allow_Data_Frame      then 1 else 0);
-      SYS_CFG_Reg.FFAA := (if Allow_Ack_Frame       then 1 else 0);
-      SYS_CFG_Reg.FFAM := (if Allow_MAC_Cmd_Frame   then 1 else 0);
-      SYS_CFG_Reg.FFAR := (if Allow_Reserved_Frame  then 1 else 0);
-      SYS_CFG_Reg.FFA4 := (if Allow_Frame_Type_4    then 1 else 0);
-      SYS_CFG_Reg.FFA5 := (if Allow_Frame_Type_5    then 1 else 0);
+      SYS_CFG_Reg.FFBC := (if Behave_As_Coordinator then Enabled else Disabled);
+      SYS_CFG_Reg.FFAB := (if Allow_Beacon_Frame    then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFAD := (if Allow_Data_Frame      then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFAA := (if Allow_Ack_Frame       then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFAM := (if Allow_MAC_Cmd_Frame   then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFAR := (if Allow_Reserved_Frame  then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFA4 := (if Allow_Frame_Type_4    then Allowed else Not_Allowed);
+      SYS_CFG_Reg.FFA5 := (if Allow_Frame_Type_5    then Allowed else Not_Allowed);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Configure_Frame_Filtering;
 
@@ -803,7 +806,7 @@ is
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_STXP := (if Enabled then 0 else 1);
+      SYS_CFG_Reg.DIS_STXP := (if Enabled then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Smart_Tx_Power;
 
@@ -956,8 +959,8 @@ is
 
       SYS_CFG.Read (SYS_CFG_Reg);
       SYS_CFG_Reg.DIS_STXP := (if Config.Smart_Tx_Power_Enabled
-                               then 0   --  Don't disable smart tx power
-                               else 1); --  Disable smart tx power
+                               then Not_Disabled
+                               else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Configure_Tx_Power;
 
@@ -1356,7 +1359,9 @@ is
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.RXAUTR := (if Enabled then 1 else 0);
+      SYS_CFG_Reg.RXAUTR := (if Enabled
+                             then Register_Types.Enabled
+                             else Register_Types.Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Auto_Rx_Reenable;
 
@@ -1366,7 +1371,7 @@ is
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_DRXB := (if Enabled then 0 else 1);
+      SYS_CFG_Reg.DIS_DRXB := (if Enabled then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Rx_Double_Buffer;
 
@@ -1378,12 +1383,12 @@ is
       SYS_CFG.Read (SYS_CFG_Reg);
 
       if Timeout > 0.0 then
-         SYS_CFG_Reg.RXWTOE := 1;
+         SYS_CFG_Reg.RXWTOE := Enabled;
 
          RX_FWTO.Write ( (RXFWTO => To_Bits_16 (Timeout)) );
 
       else
-         SYS_CFG_Reg.RXWTOE := 0;
+         SYS_CFG_Reg.RXWTOE := Disabled;
 
       end if;
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1271,16 +1271,16 @@ is
 
    begin
       -- Enable calibration
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => 0,
-                                     SMXX     => 0,
-                                     LPOSC_C  => 1,
+      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
+                                     SMXX     => Clear,
+                                     LPOSC_C  => Enabled,
                                      Reserved => 0));
       Upload_AON_Config;
 
       -- Disable calibration
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => 0,
-                                     SMXX     => 0,
-                                     LPOSC_C  => 0,
+      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
+                                     SMXX     => Clear,
+                                     LPOSC_C  => Disabled,
                                      Reserved => 0));
       Upload_AON_Config;
 
@@ -1306,43 +1306,43 @@ is
    procedure Upload_AON_Config
    is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 1,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => Upload,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end Upload_AON_Config;
 
    procedure Save_Registers_To_AON
    is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 1, --  This bit auto-clears
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => Save,      --  This bit auto-clears
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end Save_Registers_To_AON;
 
    procedure Restore_Registers_From_AON
    is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 1, --  This bit auto-clears
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => Restore,   --  This bit auto-clears
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end Restore_Registers_From_AON;
 
-   procedure AON_Read_Byte (Address : in     Types.Bits_8;
+   procedure AON_Read_Byte (Address : in     AON_ADDR_Field;
                             Data    :    out Types.Bits_8)
    is
       AON_RDAT_Reg : AON_RDAT_Type;
@@ -1352,19 +1352,19 @@ is
       AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
 
       -- Enable DCA_ENAB
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 1,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Enabled,
                                      Reserved => 0));
 
       -- Now also enable DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 1,
-                                     DCA_ENAB => 1,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => Trigger_Read,
+                                     DCA_ENAB => Enabled,
                                      Reserved => 0));
 
       -- Read the result
@@ -1372,18 +1372,18 @@ is
       Data := AON_RDAT_Reg.AON_RDAT;
 
       -- Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Read_Byte;
 
-   procedure AON_Contiguous_Read (Start_Address : in     Types.Bits_8;
+   procedure AON_Contiguous_Read (Start_Address : in     AON_ADDR_Field;
                                   Data          :    out Types.Byte_Array)
    is
-      Address      : Types.Bits_8 := Start_Address;
+      Address      : AON_ADDR_Field := Start_Address;
       AON_RDAT_Reg : AON_RDAT_Type;
 
    begin
@@ -1392,19 +1392,19 @@ is
          AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
 
          -- Enable DCA_ENAB
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                        SAVE     => 0,
-                                        UPL_CFG  => 0,
-                                        DCA_READ => 0,
-                                        DCA_ENAB => 1,
+         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                        SAVE     => No_Action,
+                                        UPL_CFG  => No_Action,
+                                        DCA_READ => No_Action,
+                                        DCA_ENAB => Enabled,
                                         Reserved => 0));
 
          -- Now also enable DCA_READ
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                        SAVE     => 0,
-                                        UPL_CFG  => 0,
-                                        DCA_READ => 1,
-                                        DCA_ENAB => 1,
+         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                        SAVE     => No_Action,
+                                        UPL_CFG  => No_Action,
+                                        DCA_READ => Trigger_Read,
+                                        DCA_ENAB => Enabled,
                                         Reserved => 0));
 
          -- Read the result
@@ -1415,15 +1415,15 @@ is
       end loop;
 
       -- Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Contiguous_Read;
 
-   procedure AON_Scatter_Read (Addresses : in     Types.Byte_Array;
+   procedure AON_Scatter_Read (Addresses : in     AON_Address_Array;
                                Data      :    out Types.Byte_Array)
    is
       AON_RDAT_Reg : AON_RDAT_Type;
@@ -1434,24 +1434,24 @@ is
    begin
       Data := (others => 0); -- workaround for flow analysis.
 
-      for I in Natural range 0 .. Data'Length - 1 loop
+      for I in 0 .. Data'Length - 1 loop
          -- Load address
          AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Addresses (A_First + I)));
 
          -- Enable DCA_ENAB
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                        SAVE     => 0,
-                                        UPL_CFG  => 0,
-                                        DCA_READ => 0,
-                                        DCA_ENAB => 1,
+         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                        SAVE     => No_Action,
+                                        UPL_CFG  => No_Action,
+                                        DCA_READ => No_Action,
+                                        DCA_ENAB => Enabled,
                                         Reserved => 0));
 
          -- Now also enable DCA_READ
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                        SAVE     => 0,
-                                        UPL_CFG  => 0,
-                                        DCA_READ => 1,
-                                        DCA_ENAB => 1,
+         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                        SAVE     => No_Action,
+                                        UPL_CFG  => No_Action,
+                                        DCA_READ => Trigger_Read,
+                                        DCA_ENAB => Enabled,
                                         Reserved => 0));
 
          -- Read the result
@@ -1460,15 +1460,15 @@ is
       end loop;
 
       -- Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => 0,
-                                     SAVE     => 0,
-                                     UPL_CFG  => 0,
-                                     DCA_READ => 0,
-                                     DCA_ENAB => 0,
+      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
+                                     SAVE     => No_Action,
+                                     UPL_CFG  => No_Action,
+                                     DCA_READ => No_Action,
+                                     DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Scatter_Read;
 
-   procedure Configure_Sleep_Count (Sleep_Count : in Types.Bits_16)
+   procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field)
    is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
 
@@ -1479,36 +1479,36 @@ is
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       -- Make sure we don't accidentally sleep
-      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => 0,
-                                     WAKE_PIN  => 0,
-                                     WAKE_SPI  => 0,
-                                     WAKE_CNT  => 0,
-                                     LPDIV_EN  => 0,
-                                     LPCLKDIVA => 0,
-                                     SLEEP_TIM => 0));
+      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
+                                     WAKE_PIN  => Disabled,
+                                     WAKE_SPI  => Disabled,
+                                     WAKE_CNT  => Disabled,
+                                     LPDIV_EN  => Disabled,
+                                     LPCLKDIVA => <>,
+                                     SLEEP_TIM => <>));
 
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => 0,
-                                     SMXX     => 0,
-                                     LPOSC_C  => 0,
+      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
+                                     SMXX     => Clear,
+                                     LPOSC_C  => Disabled,
                                      Reserved => 0));
 
       -- Disable the sleep counter
       Upload_AON_Config;
 
       -- Set the new value
-      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => 0,
-                                     WAKE_PIN  => 0,
-                                     WAKE_SPI  => 0,
-                                     WAKE_CNT  => 0,
-                                     LPDIV_EN  => 0,
-                                     LPCLKDIVA => 0,
+      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
+                                     WAKE_PIN  => Disabled,
+                                     WAKE_SPI  => Disabled,
+                                     WAKE_CNT  => Disabled,
+                                     LPDIV_EN  => Disabled,
+                                     LPCLKDIVA => <>,
                                      SLEEP_TIM => Sleep_Count));
       Upload_AON_Config;
 
       -- Enable the new value
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => 1,
-                                     SMXX     => 0,
-                                     LPOSC_C  => 0,
+      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Enabled,
+                                     SMXX     => Clear,
+                                     LPOSC_C  => Disabled,
                                      Reserved => 0));
 
       PMSC_CTRL0_Reg.SYSCLKS := 2#00#;

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -114,39 +114,30 @@ is
          6      => 0);
 
    -- These values for DRX_TUNE0b are given by the user manual
-   DRX_TUNE0b_Values : constant array (Data_Rates, Boolean) of Types.Bits_16
-     := (Data_Rate_110k =>
-           (False => 16#000A#, -- standard SFD
-            True  => 16#0016#),-- non-standard SFD
-         Data_Rate_850k =>
-           (False => 16#0001#, -- standard SFD
-            True  => 16#0006#),-- non-standard SFD
-         Data_Rate_6M8  =>
-           (False => 16#0001#, -- standard SFD
-            True  => 16#0002#) -- non-standard SFD
-        );
+   DRX_TUNE0b_Values : constant array (Data_Rates, Boolean) of DRX_TUNE0b_Field
+     := (Data_Rate_110k => (False => DRX_TUNE0b_110K_STD,
+                            True  => DRX_TUNE0b_110K_Non_STD),
+         Data_Rate_850k => (False => DRX_TUNE0b_850K_STD,
+                            True  => DRX_TUNE0b_850K_Non_STD),
+         Data_Rate_6M8  => (False => DRX_TUNE0b_6M8_STD,
+                            True  => DRX_TUNE0b_6M8_Non_STD));
 
    -- These values for DRX_TUNE1a are given by the user manual
-   DRX_TUNE1a_Values : constant array (PRF_Type) of Types.Bits_16
-     := (PRF_16MHz => 16#0087#,
-         PRF_64MHz => 16#008D#);
+   DRX_TUNE1a_Values : constant array (PRF_Type) of DRX_TUNE1a_Field
+     := (PRF_16MHz => DRX_TUNE1a_16MHz,
+         PRF_64MHz => DRX_TUNE1a_64MHz);
 
    -- These values for DRX_TUNE2 are given by the user manual
    DRX_TUNE2_Values : constant array (Preamble_Acq_Chunk_Length,
-                                      PRF_Type) of Types.Bits_32
-     := (PAC_8  =>
-           (PRF_16MHz => 16#311A002D#,
-            PRF_64MHz => 16#313B006B#),
-         PAC_16 =>
-           (PRF_16MHz => 16#331A0052#,
-            PRF_64MHz => 16#333B00BE#),
-         PAC_32 =>
-           (PRF_16MHz => 16#351A009A#,
-            PRF_64MHz => 16#353B015E#),
-         PAC_64 =>
-           (PRF_16MHz => 16#371A011D#,
-            PRF_64MHz => 16#373B0296#)
-        );
+                                      PRF_Type) of DRX_TUNE2_Field
+     := (PAC_8  => (PRF_16MHz => DRX_TUNE2_PAC8_16MHz,
+                    PRF_64MHz => DRX_TUNE2_PAC8_64MHz),
+         PAC_16 => (PRF_16MHz => DRX_TUNE2_PAC16_16MHz,
+                    PRF_64MHz => DRX_TUNE2_PAC16_64MHz),
+         PAC_32 => (PRF_16MHz => DRX_TUNE2_PAC32_16MHz,
+                    PRF_64MHz => DRX_TUNE2_PAC32_64MHz),
+         PAC_64 => (PRF_16MHz => DRX_TUNE2_PAC64_16MHz,
+                    PRF_64MHz => DRX_TUNE2_PAC64_64MHz));
 
    -- These values for AGC_TUNE1 are given by the user manual
    AGC_TUNE1_Values : constant array (PRF_Type) of AGC_TUNE1_Field
@@ -435,8 +426,7 @@ is
    procedure Write_Rx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
    is
    begin
-      LDE_RXANTD.Write
-        ( (LDE_RXANTD => To_Bits_16 (Antenna_Delay)) );
+      LDE_RXANTD.Write ( (LDE_RXANTD => To_Bits_16 (Antenna_Delay)) );
    end Write_Rx_Antenna_Delay;
 
 
@@ -454,14 +444,10 @@ is
 
       if Data_Rate = Data_Rate_110k then
          --  110 k data rate has special handling
-         LDE_REPC.Write
-           (LDE_REPC_Type'
-              (LDE_REPC => REPC_Coeff / 8));
+         LDE_REPC.Write ( (LDE_REPC => REPC_Coeff / 8) );
 
       else
-         LDE_REPC.Write
-           (LDE_REPC_Type'
-              (LDE_REPC => REPC_Coeff));
+         LDE_REPC.Write ( (LDE_REPC => REPC_Coeff) );
       end if;
 
    end Configure_LDE;
@@ -469,26 +455,16 @@ is
    procedure Configure_PLL (Channel : in Channel_Number)
    is
    begin
-      FS_PLLCFG.Write ( (FS_PLLCFG => FS_PLLCFG_Values (Positive (Channel))) );
-
-      FS_PLLTUNE.Write
-        ( (FS_PLLTUNE => FS_PLLTUNE_Values (Positive (Channel))) );
-
+      FS_PLLCFG.Write  ( (FS_PLLCFG  => FS_PLLCFG_Values  (Positive (Channel))) );
+      FS_PLLTUNE.Write ( (FS_PLLTUNE => FS_PLLTUNE_Values (Positive (Channel))) );
       FS_XTALT.Write (FS_XTALT_Value);
    end Configure_PLL;
 
    procedure Configure_RF (Channel : in Channel_Number)
    is
    begin
-      RF_RXCTRLH.Write
-        (RF_RXCTRLH_Type'
-           (RF_RXCTRLH => RF_RXCTRLH_Values (Positive (Channel)))
-        );
-
-      RF_TXCTRL.Write
-        (RF_TXCTRL_Type'
-           (RF_TXCTRL => RF_TXCTRL_Values (Positive (Channel)))
-        );
+      RF_RXCTRLH.Write ( (RF_RXCTRLH => RF_RXCTRLH_Values (Positive (Channel))) );
+      RF_TXCTRL.Write  ( (RF_TXCTRL  => RF_TXCTRL_Values (Positive (Channel))) );
 
    end Configure_RF;
 
@@ -500,53 +476,23 @@ is
                             Nonstandard_SFD    : in Boolean)
    is
    begin
-      DRX_TUNE0b.Write
-        (DRX_TUNE0b_Type'
-           (DRX_TUNE0b => DRX_TUNE0b_Values (Data_Rate, Nonstandard_SFD))
-        );
-
-      DRX_TUNE1a.Write
-        (DRX_TUNE1a_Type'
-           (DRX_TUNE1a => DRX_TUNE1a_Values (PRF))
-        );
+      DRX_TUNE0b.Write ( (DRX_TUNE0b => DRX_TUNE0b_Values (Data_Rate,
+                                                           Nonstandard_SFD)) );
+      DRX_TUNE1a.Write ( (DRX_TUNE1a => DRX_TUNE1a_Values (PRF)) );
 
       if Data_Rate = Data_Rate_110k then
-         DRX_TUNE1b.Write
-           (DRX_TUNE1b_Type'
-              (DRX_TUNE1b => 16#0064#)
-           );
+         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_110K) );
 
       elsif Tx_Preamble_Length = PLEN_64 then
-         DRX_TUNE1b.Write
-           (DRX_TUNE1b_Type'
-              (DRX_TUNE1b => 16#0010#)
-           );
-
-         DRX_TUNE4H.Write
-           (DRX_TUNE4H_Type'
-              (DRX_TUNE4H => 16#0010#)
-           );
+         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_6M8) );
+         DRX_TUNE4H.Write ( (DRX_TUNE4H => DRX_TUNE4H_Preamble_64) );
       else
-         DRX_TUNE1b.Write
-           (DRX_TUNE1b_Type'
-              (DRX_TUNE1b => 16#0020#)
-           );
-
-         DRX_TUNE4H.Write
-           (DRX_TUNE4H_Type'
-              (DRX_TUNE4H => 16#0028#)
-           );
+         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_850K_6M8) );
+         DRX_TUNE4H.Write ( (DRX_TUNE4H => DRX_TUNE4H_Others) );
       end if;
 
-      DRX_TUNE2.Write
-        (DRX_TUNE2_Type'
-           (DRX_TUNE2 => DRX_TUNE2_Values (PAC, PRF))
-        );
-
-      DRX_SFDTOC.Write
-        (DRX_SFDTOC_Type'
-           (DRX_SFDTOC => Types.Bits_16 (SFD_Timeout))
-        );
+      DRX_TUNE2.Write  ( (DRX_TUNE2  => DRX_TUNE2_Values (PAC, PRF)) );
+      DRX_SFDTOC.Write ( (DRX_SFDTOC => DRX_SFDTOC_Field (SFD_Timeout)) );
    end Configure_DRX;
 
 
@@ -554,20 +500,9 @@ is
    is
    begin
 
-      AGC_TUNE2.Write
-        (AGC_TUNE2_Type'
-           (AGC_TUNE2 => AGC_TUNE2_Value)
-        );
-
-      AGC_TUNE1.Write
-        (AGC_TUNE1_Type'
-           (AGC_TUNE1 => AGC_TUNE1_Values (PRF))
-        );
-
-      AGC_TUNE3.Write
-        (AGC_TUNE3_Type'
-           (AGC_TUNE3 => AGC_TUNE3_Value)
-        );
+      AGC_TUNE2.Write ( (AGC_TUNE2 => AGC_TUNE2_Value) );
+      AGC_TUNE1.Write ( (AGC_TUNE1 => AGC_TUNE1_Values (PRF)) );
+      AGC_TUNE3.Write ( (AGC_TUNE3 => AGC_TUNE3_Value) );
 
    end Configure_AGC;
 
@@ -1320,7 +1255,7 @@ is
    procedure Set_Preamble_Detect_Timeout (Timeout : in Types.Bits_16)
    is
    begin
-      DRX_PRETOC.Write ( (DRX_PRETOC => Timeout) );
+      DRX_PRETOC.Write ( (DRX_PRETOC => DRX_PRETOC_Field (Timeout)) );
    end Set_Preamble_Detect_Timeout;
 
    procedure Calibrate_Sleep_Count

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1160,7 +1160,7 @@ is
 
    begin
       SYS_TIME.Read (SYS_TIME_Reg);
-      Timestamp := To_Coarse_System_Time (SYS_TIME_Reg.SYS_TIME);
+      Timestamp := SYS_TIME_Reg.SYS_TIME;
    end Read_System_Timestamp;
 
    procedure Check_Overrun (Overrun : out Boolean)

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -69,24 +69,28 @@ is
            24 => Bits_16 (0.22 * 2**16));
 
    -- These values for FS_PLLCFG are given by the user manual
-   FS_PLLCFG_Values : constant array (Positive range 1 .. 7) of Types.Bits_32
-     := (1   => 16#09000407#,
-         2|4 => 16#08400508#,
-         3   => 16#08401009#,
-         5|7 => 16#0800041D#,
+   FS_PLLCFG_Values : constant array (Positive range 1 .. 7) of FS_PLLCFG_Field
+     := (1 => FS_PLLCFG_Channel_1,
+         2 => FS_PLLCFG_Channel_2,
+         3 => FS_PLLCFG_Channel_3,
+         4 => FS_PLLCFG_Channel_4,
+         5 => FS_PLLCFG_Channel_5,
+         7 => FS_PLLCFG_Channel_7,
          -- Note that channel 6 is not a valid channel. However, Channel_Number
          -- cannot be used as the array index type since it has a predicate.
-         6   => 0);
+         6 => 0);
 
    -- These values for FS_PLLTUNE are given by the user manual
-   FS_PLLTUNE_Values : constant array (Positive range 1 .. 7) of Types.Bits_8
-     := (1   => 16#1E#,
-         2|4 => 16#26#,
-         3   => 16#5E#,
-         5|7 => 16#BE#,
+   FS_PLLTUNE_Values : constant array (Positive range 1 .. 7) of FS_PLLTUNE_Field
+     := (1 => FS_PLLTUNE_Channel_1,
+         2 => FS_PLLTUNE_Channel_2,
+         3 => FS_PLLTUNE_Channel_3,
+         4 => FS_PLLTUNE_Channel_4,
+         5 => FS_PLLTUNE_Channel_5,
+         7 => FS_PLLTUNE_Channel_7,
          -- Note that channel 6 is not a valid channel. However, Channel_Number
          -- cannot be used as the array index type since it has a predicate.
-         6   => 0);
+         6 => 0);
 
    -- These values for FS_PLLCFG are ported from the C decadriver
    FS_XTALT_Value : constant FS_XTALT_Type
@@ -1513,7 +1517,7 @@ is
    end Configure_Sleep_Count;
 
 
-   procedure Set_XTAL_Trim (Trim : in Types.Bits_5)
+   procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field)
    is
       FS_XTALT_Reg : FS_XTALT_Type;
 

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1000,15 +1000,15 @@ is
 
    begin
       SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => (if Auto_Append_FCS then 0 else 1),
-         TXSTRT     => 1,
-         TXDLYS     => 0, --  No delay
-         CANSFCS    => 0,
-         TRXOFF     => 0,
-         WAIT4RESP  => (if Rx_After_Tx then 1 else 0),
-         RXENAB     => 0,
-         RXDLYE     => 0,
-         HRBPT      => 0,
+        (SFCST      => (if Auto_Append_FCS then Not_Suppressed else Suppressed),
+         TXSTRT     => Start_Tx,
+         TXDLYS     => Not_Delayed,
+         CANSFCS    => Not_Cancelled,
+         TRXOFF     => No_Action,
+         WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
+         RXENAB     => No_Action,
+         RXDLYE     => Not_Delayed,
+         HRBPT      => No_Action,
          Reserved_1 => 0,
          Reserved_2 => 0,
          Reserved_3 => 0);
@@ -1024,15 +1024,15 @@ is
 
    begin
       SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => 0,
-         TXSTRT     => 1,
-         TXDLYS     => 1, --  Delayed transmit
-         CANSFCS    => 0,
-         TRXOFF     => 0,
-         WAIT4RESP  => (if Rx_After_Tx then 1 else 0),
-         RXENAB     => 0,
-         RXDLYE     => 0,
-         HRBPT      => 0,
+        (SFCST      => Not_Suppressed,
+         TXSTRT     => Start_Tx,
+         TXDLYS     => Delayed,
+         CANSFCS    => Not_Cancelled,
+         TRXOFF     => No_Action,
+         WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
+         RXENAB     => No_Action,
+         RXDLYE     => Not_Delayed,
+         HRBPT      => No_Action,
          Reserved_1 => 0,
          Reserved_2 => 0,
          Reserved_3 => 0);
@@ -1046,15 +1046,15 @@ is
 
       else
          -- Cancel the transmit
-         SYS_CTRL_Reg := SYS_CTRL_Type'(SFCST      => 0,
-                                        TXSTRT     => 0,
-                                        TXDLYS     => 0,
-                                        CANSFCS    => 0,
-                                        TRXOFF     => 1,
-                                        WAIT4RESP  => 0,
-                                        RXENAB     => 0,
-                                        RXDLYE     => 0,
-                                        HRBPT      => 0,
+         SYS_CTRL_Reg := SYS_CTRL_Type'(SFCST      => Not_Suppressed,
+                                        TXSTRT     => No_Action,
+                                        TXDLYS     => Not_Delayed,
+                                        CANSFCS    => Not_Cancelled,
+                                        TRXOFF     => Transceiver_Off,
+                                        WAIT4RESP  => No_Wait,
+                                        RXENAB     => No_Action,
+                                        RXDLYE     => Not_Delayed,
+                                        HRBPT      => No_Action,
                                         Reserved_1 => 0,
                                         Reserved_2 => 0,
                                         Reserved_3 => 0);
@@ -1080,7 +1080,7 @@ is
    procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time)
    is
    begin
-      DX_TIME.Write (DX_TIME_Type'(DX_TIME => To_Bits_40 (Delay_Time)));
+      DX_TIME.Write (DX_TIME_Type'(DX_TIME => Delay_Time));
    end Set_Delayed_Tx_Rx_Time;
 
    procedure Set_Sleep_After_Tx (Enabled : in Boolean)
@@ -1186,11 +1186,8 @@ is
                                      others     => 0));
 
       -- Disable Tx/Rx
-      SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF     => 1,
-                                     Reserved_1 => 0,
-                                     Reserved_2 => 0,
-                                     Reserved_3 => 0,
-                                     others     => 0));
+      SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF     => Transceiver_Off,
+                                     others     => <>));
 
       -- Force transceiver off; don't want to see any new events.
       SYS_STATUS.Write (SYS_STATUS_Type'(AAT        => 1,
@@ -1246,7 +1243,7 @@ is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
    begin
       SYS_CTRL.Read (SYS_CTRL_Reg);
-      SYS_CTRL_Reg.HRBPT := 1;
+      SYS_CTRL_Reg.HRBPT := Toggle;
       SYS_CTRL.Write (SYS_CTRL_Reg);
    end Toggle_Host_Side_Rx_Buffer_Pointer;
 
@@ -1274,15 +1271,15 @@ is
       Sync_Rx_Buffer_Pointers;
 
       SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => 0,
-         TXSTRT     => 0,
-         TXDLYS     => 0,
-         CANSFCS    => 0,
-         TRXOFF     => 0,
-         WAIT4RESP  => 0,
-         RXENAB     => 1,
-         RXDLYE     => 0,
-         HRBPT      => 0,
+        (SFCST      => Not_Suppressed,
+         TXSTRT     => No_Action,
+         TXDLYS     => Not_Delayed,
+         CANSFCS    => Not_Cancelled,
+         TRXOFF     => No_Action,
+         WAIT4RESP  => No_Wait,
+         RXENAB     => Start_Rx,
+         RXDLYE     => Not_Delayed,
+         HRBPT      => No_Action,
          Reserved_1 => 0,
          Reserved_2 => 0,
          Reserved_3 => 0);
@@ -1301,15 +1298,15 @@ is
       Sync_Rx_Buffer_Pointers;
 
       SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => 0,
-         TXSTRT     => 0,
-         TXDLYS     => 0,
-         CANSFCS    => 0,
-         TRXOFF     => 0,
-         WAIT4RESP  => 0,
-         RXENAB     => 1,
-         RXDLYE     => 1, --  Delayed RX
-         HRBPT      => 0,
+        (SFCST      => Not_Suppressed,
+         TXSTRT     => No_Action,
+         TXDLYS     => Not_Delayed,
+         CANSFCS    => Not_Cancelled,
+         TRXOFF     => No_Action,
+         WAIT4RESP  => No_Wait,
+         RXENAB     => Start_Rx,
+         RXDLYE     => Delayed,
+         HRBPT      => No_Action,
          Reserved_1 => 0,
          Reserved_2 => 0,
          Reserved_3 => 0);
@@ -1323,7 +1320,7 @@ is
          Force_Tx_Rx_Off;
 
          -- Clear the delay bit
-         SYS_CTRL_Reg.RXDLYE := 0;
+         SYS_CTRL_Reg.RXDLYE := Not_Delayed;
          SYS_CTRL.Write (SYS_CTRL_Reg);
 
          Result := Error;
@@ -1388,7 +1385,7 @@ is
       if Timeout > 0.0 then
          SYS_CFG_Reg.RXWTOE := Enabled;
 
-         RX_FWTO.Write ( (RXFWTO => To_Bits_16 (Timeout)) );
+         RX_FWTO.Write ( (RXFWTO => Timeout) );
 
       else
          SYS_CFG_Reg.RXWTOE := Disabled;

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -94,21 +94,21 @@ is
          Reserved => 2#011#);
 
    -- These values for RF_TXCTRL are given by the user manual
-   RF_TXCTRL_Values : constant array (Positive range 1 .. 7) of Types.Bits_32
-     := (1 => 16#00006C50#,
-         2 => 16#00056CA0#,
-         3 => 16#00086CC0#,
-         4 => 16#00045C80#,
-         5 => 16#001E3FE0#,
-         7 => 16#001E7DE0#,
+   RF_TXCTRL_Values : constant array (Positive range 1 .. 7) of RF_TXCTRL_Field
+     := (1 => RF_TXCTRL_Channel_1,
+         2 => RF_TXCTRL_Channel_2,
+         3 => RF_TXCTRL_Channel_3,
+         4 => RF_TXCTRL_Channel_4,
+         5 => RF_TXCTRL_Channel_5,
+         7 => RF_TXCTRL_Channel_7,
          -- Note that channel 6 is not a valid channel. However, Channel_Number
          -- cannot be used as the array index type since it has a predicate.
          6 => 0);
 
    -- These values for RF_RXCTRLH are given by the user manual
-   RF_RXCTRLH_Values : constant array (Positive range 1 .. 7) of Types.Bits_8
-     := (1..3|5 => 16#D8#,
-         4|7    => 16#BC#,
+   RF_RXCTRLH_Values : constant array (Positive range 1 .. 7) of RF_RXCTRLH_Field
+     := (1..3|5 => RF_RXCTRLH_500MHz,
+         4|7    => RF_RXCTRLH_900MHz,
          -- Note that channel 6 is not a valid channel. However, Channel_Number
          -- cannot be used as the array index type since it has a predicate.
          6      => 0);

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -188,12 +188,12 @@ is
 
       --  Kick off the NV MEM load
       OTP_CTRL.Write (OTP_CTRL_Type'
-                        (OTPRDEN    => 0,
-                         OTPREAD    => 0,
-                         OTPMRWR    => 0,
-                         OTPPROG    => 0,
-                         OTPMR      => 0,
-                         LDELOAD    => 1,
+                        (OTPRDEN    => Disabled,
+                         OTPREAD    => No_Action,
+                         OTPMRWR    => Clear,
+                         OTPPROG    => Clear,
+                         OTPMR      => Clear,
+                         LDELOAD    => Load_LDE_Microcode,
                          Reserved_1 => 0,
                          Reserved_2 => 0,
                          Reserved_3 => 0));
@@ -285,7 +285,7 @@ is
    end Enable_Clocks;
 
 
-   procedure Read_OTP (Address : in     Bits_11;
+   procedure Read_OTP (Address : in     OTP_ADDR_Field;
                        Word    :    out Bits_32)
    is
       CTRL_Reg : OTP_CTRL_Type;
@@ -298,12 +298,12 @@ is
 
       -- Trigger OTP read
       CTRL_Reg := OTP_CTRL_Type'
-        (OTPRDEN    => 1,
-         OTPREAD    => 1,
-         OTPMRWR    => 0,
-         OTPPROG    => 0,
-         OTPMR      => 0,
-         LDELOAD    => 0,
+        (OTPRDEN    => Enabled,
+         OTPREAD    => Trigger_Read,
+         OTPMRWR    => Clear,
+         OTPPROG    => Clear,
+         OTPMR      => Clear,
+         LDELOAD    => No_Action,
          Reserved_1 => 0,
          Reserved_2 => 0,
          Reserved_3 => 0);
@@ -311,8 +311,8 @@ is
       OTP_CTRL.Write (CTRL_Reg);
 
       -- OTPRDEN is not self-clearing. Also clear OPTREAD
-      CTRL_Reg.OTPRDEN := 0;
-      CTRL_Reg.OTPREAD := 0;
+      CTRL_Reg.OTPRDEN := Disabled;
+      CTRL_Reg.OTPREAD := No_Action;
       OTP_CTRL.Write (CTRL_Reg);
 
       -- Read back the OTP word
@@ -755,7 +755,7 @@ is
                                       PRF      : in     PRF_Type;
                                       Tx_Power :    out TX_POWER_Type)
    is
-      Address : Bits_11;
+      Address : OTP_ADDR_Field;
       Word    : Bits_32;
 
       function Word_To_TX_POWER is new Ada.Unchecked_Conversion

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -176,11 +176,11 @@ is
    begin
       --  Set up clocks
       PMSC_CTRL0.Read (PMSC_CTRL0_Reg);
-      PMSC_CTRL0_Reg.SYSCLKS := 1;
-      PMSC_CTRL0_Reg.RXCLKS  := 0;
-      PMSC_CTRL0_Reg.TXCLKS  := 0;
-      PMSC_CTRL0_Reg.FACE    := 0;
-      PMSC_CTRL0_Reg.ADCCE   := 0;
+      PMSC_CTRL0_Reg.SYSCLKS := Force_XTI;
+      PMSC_CTRL0_Reg.RXCLKS  := Auto;
+      PMSC_CTRL0_Reg.TXCLKS  := Auto;
+      PMSC_CTRL0_Reg.FACE    := Disabled;
+      PMSC_CTRL0_Reg.ADCCE   := Disabled;
       PMSC_CTRL0_Reg.Reserved_1 := 2#110#;
       --  Writing to these Reserved bits is undocumented in the User Manual,
       --  but the DecaWave C code sets these bits, so it serves some purpose.
@@ -218,7 +218,7 @@ is
       pragma Warnings (GNATprove, On, "statement has no effect");
 
       --  Default clocks
-      PMSC_CTRL0_Reg.SYSCLKS    := 0;
+      PMSC_CTRL0_Reg.SYSCLKS    := Auto;
       PMSC_CTRL0_Reg.Reserved_1 := 2#100#;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
    end Load_LDE_From_ROM;
@@ -233,10 +233,10 @@ is
 
       case Clock is
          when Enable_All_Seq =>
-            PMSC_CTRL0_Reg.SYSCLKS := 2#00#;
-            PMSC_CTRL0_Reg.RXCLKS  := 2#00#;
-            PMSC_CTRL0_Reg.TXCLKS  := 2#00#;
-            PMSC_CTRL0_Reg.FACE    := 0;
+            PMSC_CTRL0_Reg.SYSCLKS := Auto;
+            PMSC_CTRL0_Reg.RXCLKS  := Auto;
+            PMSC_CTRL0_Reg.TXCLKS  := Auto;
+            PMSC_CTRL0_Reg.FACE    := Disabled;
 
             -- Need to write the above changes before setting GPCE
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
@@ -246,14 +246,14 @@ is
             --  but the DecaWave C code masks these bits.
 
          when Force_Sys_XTI =>
-            PMSC_CTRL0_Reg.SYSCLKS := 2#01#;
+            PMSC_CTRL0_Reg.SYSCLKS := Force_XTI;
 
          when Force_Sys_PLL =>
-            PMSC_CTRL0_Reg.SYSCLKS := 2#10#;
+            PMSC_CTRL0_Reg.SYSCLKS := Force_PLL;
 
          when Read_Acc_On =>
-            PMSC_CTRL0_Reg.RXCLKS    := 2#10#;
-            PMSC_CTRL0_Reg.FACE      := 1;
+            PMSC_CTRL0_Reg.RXCLKS    := Force_PLL;
+            PMSC_CTRL0_Reg.FACE      := Enabled;
 
             -- Need to write the above changes before setting SOFTRESET
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
@@ -261,8 +261,8 @@ is
             PMSC_CTRL0_Reg.SOFTRESET := PMSC_CTRL0_Reg.SOFTRESET or 2#1000#;
 
          when Read_Acc_Off =>
-            PMSC_CTRL0_Reg.RXCLKS    := 2#00#;
-            PMSC_CTRL0_Reg.FACE      := 0;
+            PMSC_CTRL0_Reg.RXCLKS    := Auto;
+            PMSC_CTRL0_Reg.FACE      := Disabled;
 
             -- Need to write the above changes before clearing SOFTRESET
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
@@ -276,7 +276,7 @@ is
             PMSC_CTRL0_Reg.Reserved_1 := PMSC_CTRL0_Reg.Reserved_1 and 2#011#;
 
          when Force_Tx_PLL =>
-            PMSC_CTRL0_Reg.TXCLKS := 2#10#;
+            PMSC_CTRL0_Reg.TXCLKS := Force_PLL;
 
       end case;
 
@@ -951,7 +951,9 @@ is
 
    begin
       PMSC_CTRL1.Read (PMSC_CTRL1_Reg);
-      PMSC_CTRL1_Reg.ATXSLP := (if Enabled then 1 else 0);
+      PMSC_CTRL1_Reg.ATXSLP := (if Enabled
+                                then Register_Types.Enabled
+                                else Register_Types.Disabled);
       PMSC_CTRL1.Write (PMSC_CTRL1_Reg);
    end Set_Sleep_After_Tx;
 
@@ -1285,8 +1287,8 @@ is
       Upload_AON_Config;
 
       PMSC_CTRL0.Read (PMSC_CTRL0_Reg);
-      PMSC_CTRL0_Reg.SYSCLKS := 2#01#;
-      PMSC_CTRL0_Reg.RXCLKS  := 2#00#;
+      PMSC_CTRL0_Reg.SYSCLKS := Force_XTI;
+      PMSC_CTRL0_Reg.RXCLKS  := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       -- Read number of XTAL/2 cycles per LP osc cycle
@@ -1298,7 +1300,7 @@ is
             or Shift_Left (Types.Bits_16 (Data (2)), 8));
 
       -- Reset PMSC_CTRL0
-      PMSC_CTRL0_Reg.SYSCLKS := 2#00#;
+      PMSC_CTRL0_Reg.SYSCLKS := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
    end Calibrate_Sleep_Count;
@@ -1474,8 +1476,8 @@ is
 
    begin
       PMSC_CTRL0.Read (PMSC_CTRL0_Reg);
-      PMSC_CTRL0_Reg.SYSCLKS := 2#01#;
-      PMSC_CTRL0_Reg.RXCLKS  := 2#00#;
+      PMSC_CTRL0_Reg.SYSCLKS := Force_XTI;
+      PMSC_CTRL0_Reg.RXCLKS  := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       -- Make sure we don't accidentally sleep
@@ -1511,7 +1513,7 @@ is
                                      LPOSC_C  => Disabled,
                                      Reserved => 0));
 
-      PMSC_CTRL0_Reg.SYSCLKS := 2#00#;
+      PMSC_CTRL0_Reg.SYSCLKS := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
    end Configure_Sleep_Count;
@@ -1552,23 +1554,29 @@ is
 
       --  Enable LP oscillator to run from counter, turn on debounce clock
       PMSC_CTRL0.Read (PMSC_CTRL0_Reg);
-      PMSC_CTRL0_Reg.GPDCE := 1;
-      PMSC_CTRL0_Reg.KHZCLKEN := 1;
+      PMSC_CTRL0_Reg.GPDCE := Enabled;
+      PMSC_CTRL0_Reg.KHZCLKEN := Enabled;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       -- Enable LEDs
       PMSC_LEDC.Read (PMSC_LEDC_Reg);
-      PMSC_LEDC_Reg.BLINK_TIM := 16; -- 16 * 14 ms = 224 ms
-      PMSC_LEDC_Reg.BLNKEN    := (if LED_Enabled then 1 else 0);
+      PMSC_LEDC_Reg.BLINK_TIM := 0.224;
+      PMSC_LEDC_Reg.BLNKEN    := (if LED_Enabled then Enabled else Disabled);
       PMSC_LEDC.Write (PMSC_LEDC_Reg);
 
       if Test_Flash then
          --  Blink each LED
-         PMSC_LEDC_Reg.BLNKNOW := 2#1111#;
+         PMSC_LEDC_Reg.BLNKNOW_RXOKLED := Blink_Now;
+         PMSC_LEDC_Reg.BLNKNOW_SFDLED  := Blink_Now;
+         PMSC_LEDC_Reg.BLNKNOW_RXLED   := Blink_Now;
+         PMSC_LEDC_Reg.BLNKNOW_TXLED   := Blink_Now;
          PMSC_LEDC.Write (PMSC_LEDC_Reg);
 
          --  Clear forced bits
-         PMSC_LEDC_Reg.BLNKNOW := 2#0000#;
+         PMSC_LEDC_Reg.BLNKNOW_RXOKLED := No_Action;
+         PMSC_LEDC_Reg.BLNKNOW_SFDLED  := No_Action;
+         PMSC_LEDC_Reg.BLNKNOW_RXLED   := No_Action;
+         PMSC_LEDC_Reg.BLNKNOW_TXLED   := No_Action;
          PMSC_LEDC.Write (PMSC_LEDC_Reg);
       end if;
    end Configure_LEDs;

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -1330,13 +1330,13 @@ is
    end Start_Rx_Delayed;
 
    procedure Set_Rx_Mode (Mode        : in Rx_Modes;
-                          Rx_On_Time  : in Types.Bits_4;
-                          Rx_Off_Time : in Coarse_System_Time)
+                          Rx_On_Time  : in RX_SNIFF_SNIFF_ONT_Field;
+                          Rx_Off_Time : in Sniff_Off_Time)
    is
    begin
       if Mode = Normal then
          RX_SNIFF.Write (RX_SNIFF_Type'(SNIFF_ONT  => 0,
-                                        SNIFF_OFFT => 0,
+                                        SNIFF_OFFT => 0.0,
                                         Reserved_1 => 0,
                                         Reserved_2 => 0));
 
@@ -1344,7 +1344,7 @@ is
          RX_SNIFF.Write
            (RX_SNIFF_Type'
               (SNIFF_ONT  => Rx_On_Time,
-               SNIFF_OFFT => Bits_8 (To_Bits_40 (Rx_Off_Time) and 16#FF#),
+               SNIFF_OFFT => Rx_Off_Time,
                Reserved_1 => 0,
                Reserved_2 => 0));
       end if;

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -1065,7 +1065,7 @@ is
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => + Sleep_Count);
 
-   procedure Set_XTAL_Trim (Trim : in Types.Bits_5)
+   procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => + Trim);
 

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -946,13 +946,11 @@ is
    --    * SYS_CTRL
 
    procedure Set_Rx_Mode (Mode        : in Rx_Modes;
-                          Rx_On_Time  : in Types.Bits_4;
-                          Rx_Off_Time : in Coarse_System_Time)
+                          Rx_On_Time  : in RX_SNIFF_SNIFF_ONT_Field;
+                          Rx_Off_Time : in Sniff_Off_Time)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => + (Mode, Rx_On_Time, Rx_Off_Time)),
-     Pre =>
-       ((if Mode = Sniff then Rx_Off_Time > 0.0)
-        and Rx_Off_Time < Coarse_System_Time'Delta * (128.0 * 2.0**8));
+     Pre => (if Mode = Sniff then Rx_Off_Time > 0.0);
    --  Enables or disables the receiver sniff mode.
    --
    --  When Mode is set to Normal then when the receiver is turned on (see

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -204,7 +204,7 @@ is
    --  This procedure configures the following registers:
    --    * PMSC_CTRL0
 
-   procedure Read_OTP (Address : in     Bits_11;
+   procedure Read_OTP (Address : in     OTP_ADDR_Field;
                        Word    :    out Bits_32)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => ((DW1000.BSP.Device_State, Word) => (DW1000.BSP.Device_State,

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -97,6 +97,9 @@ is
    type SFD_Length_Number is new Natural range 8 .. 64
      with Static_Predicate => SFD_Length_Number in 8 .. 16 | 64;
 
+   type AON_Address_Array is array (Index range <>) of AON_ADDR_Field;
+   --  Array of addresses within the AON address space.
+
    type Rx_Modes is (Normal, Sniff);
 
    type Tx_Power_Config_Type (Smart_Tx_Power_Enabled : Boolean := True) is
@@ -1026,7 +1029,7 @@ is
    --  Load the user configuration from the AON memory into the host interface
    --  register set.
 
-   procedure AON_Read_Byte (Address : in     Types.Bits_8;
+   procedure AON_Read_Byte (Address : in     AON_ADDR_Field;
                             Data    :    out Types.Bits_8)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends =>
@@ -1034,7 +1037,7 @@ is
         Data                    => (DW1000.BSP.Device_State, Address));
    -- Reads a single byte from the Always-On block.
 
-   procedure AON_Contiguous_Read (Start_Address : in     Types.Bits_8;
+   procedure AON_Contiguous_Read (Start_Address : in     AON_ADDR_Field;
                                   Data          :    out Types.Byte_Array)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
@@ -1046,7 +1049,7 @@ is
              and then Natural (Start_Address) + Data'Length <= 256);
    -- Reads a contiguous sequence of bytes from the Always-On block.
 
-   procedure AON_Scatter_Read (Addresses : in     Types.Byte_Array;
+   procedure AON_Scatter_Read (Addresses : in     AON_Address_Array;
                                Data      :    out Types.Byte_Array)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
@@ -1061,7 +1064,7 @@ is
    --  Addresses array, and stores the byte that was read in the corresponding
    --  position in the Data array.
 
-   procedure Configure_Sleep_Count (Sleep_Count : in Types.Bits_16)
+   procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => + Sleep_Count);
 

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -99,36 +99,18 @@ is
 
    type Rx_Modes is (Normal, Sniff);
 
-   type Coarse_Tx_Power_Number is delta 3.0 range 0.0 .. 18.0
-     with Small => 0.5;
-   --  GNATprove requires a Small which is a negative power of 2 or 10.
-
-   type Fine_Tx_Power_Number is delta 0.5 range 0.0 .. 15.5
-     with Small => 0.5;
-
-   type Tx_Power_Value (Coarse_Gain_Enabled : Boolean := True) is record
-      Fine_Gain : Fine_Tx_Power_Number;
-
-      case Coarse_Gain_Enabled is
-         when True =>
-            Coarse_Gain : Coarse_Tx_Power_Number;
-         when False =>
-            null;
-      end case;
-   end record;
-
    type Tx_Power_Config_Type (Smart_Tx_Power_Enabled : Boolean := True) is
       record
          case Smart_Tx_Power_Enabled is
-         when True =>
-            Boost_Normal : Tx_Power_Value;
-            Boost_500us  : Tx_Power_Value;
-            Boost_250us  : Tx_Power_Value;
-            Boost_125us  : Tx_Power_Value;
+            when True =>
+               Boost_Normal : TX_POWER_Field;
+               Boost_500us  : TX_POWER_Field;
+               Boost_250us  : TX_POWER_Field;
+               Boost_125us  : TX_POWER_Field;
 
-         when False =>
-            Boost_SHR    : Tx_Power_Value;
-            Boost_PHR    : Tx_Power_Value;
+            when False =>
+               Boost_SHR    : TX_POWER_Field;
+               Boost_PHR    : TX_POWER_Field;
          end case;
       end record;
 
@@ -247,52 +229,6 @@ is
      Depends => (DW1000.BSP.Device_State => DW1000.BSP.Device_State,
                  Antenna_Delay_16_MHz    => DW1000.BSP.Device_State,
                  Antenna_Delay_64_MHz    => DW1000.BSP.Device_State);
-
-
-   function To_Bits_8 (Config : in Tx_Power_Value) return Bits_8;
-   --  Convert a Tx power configuration to its Bits_8 representation for use
-   --  when writing to the TX_POWER register.
-   --
-   --  The TX_POWER register is composed of four Bits_8 fields, each of which
-   --  contains 3 bits for the coarse gain setting, and 5 bits for the fine
-   --  gain setting. This function converts to this Bits_8 representation.
-
-   function Fine_Gain (Tx_Power_Bits : in Bits_8) return Fine_Tx_Power_Number;
-   --  Get the fine gain setting from one of the fields in the TX_POWER
-   --  register.
-   --
-   --  The TX_POWER register is composed of four Bits_8 fields, each of which
-   --  contains 3 bits for the coarse gain setting, and 5 bits for the fine
-   --  gain setting. This function gets the fine gain parameter.
-
-   function Is_Coarse_Gain_Enabled (Tx_Power_Bits : in Bits_8) return Boolean
-   is ((Tx_Power_Bits and 2#111_00000#) /= 2#111_00000#);
-   --  Check if the coarse gain output is enabled or disabled.
-   --
-   --  The TX_POWER register is composed of four Bits_8 fields, each of which
-   --  contains 3 bits for the coarse gain setting, and 5 bits for the fine
-   --  gain setting. This function gets the coarse gain parameter.
-   --
-   --  Note that the specical value of 2#111# for the coarse gain bits in the
-   --  TX_POWER register's fields means that the coarse gain output is disabled
-   --  (only the fine gain is used). If the coarse gain is disabled, then this
-   --  function always returns False. Otherwise, it returns True.
-
-   function Coarse_Gain (Tx_Power_Bits : in Bits_8)
-                         return Coarse_Tx_Power_Number
-     with Post => (if not Is_Coarse_Gain_Enabled (Tx_Power_Bits)
-                   then Coarse_Gain'Result = 0.0);
-   --  Get the coarse gain setting from one of the fields in the TX_POWER
-   --  register.
-   --
-   --  The TX_POWER register is composed of four Bits_8 fields, each of which
-   --  contains 3 bits for the coarse gain setting, and 5 bits for the fine
-   --  gain setting. This function gets the coarse gain parameter.
-   --
-   --  Note that the specical value of 2#111# for the coarse gain bits in the
-   --  TX_POWER register's fields means that the coarse gain output is disabled
-   --  (only the fine gain is used). If the coarse gain is disabled, then this
-   --  function always returns 0.0.
 
    procedure Configure_Tx_Power (Config : Tx_Power_Config_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -106,7 +106,7 @@ is
       range 2.0**17 .. (2.0**16 - 1.0) * 2.0**17;
 
       subtype Denominator_Range is Long_Float
-      range 1.0 .. (2.0**16 - 1.0)**2;
+      range 1.0 .. (2.0**12 - 1.0)**2;
 
       N   : Numerator_Range;
       D   : Denominator_Range;
@@ -143,11 +143,11 @@ is
 
       R := Log10 (N / D);
 
-      --  The values in this assumption were generated using Wolfram|Alpha
-      --  based on the range of the Division_Result_Range subtype.
+      --  The values in this assumption are based on the mathemtical min/max
+      --  values of Log10 based on the possible range of the input: N / D.
       pragma Assume
-        (R in -4.51543668124281909693514752724080083167976452069664
-         .. 9.9339832300529300264179155790949725984287242376320911,
+        (R in -2.10699788590519423954821296166977269784955865640566952845
+         .. 9.933983230052930026417915579094972598428724237632091142242,
          "The possible output range of log10, for the possible input range");
 
       if Use_16MHz_PRF then
@@ -174,7 +174,7 @@ is
       range 1.0 .. (F_Range'Last * 3.0);
 
       subtype Denominator_Range is Long_Float
-      range 1.0 .. (2.0**16 - 1.0)**2;
+      range 1.0 .. (2.0**12 - 1.0)**2;
 
       subtype Division_Result_Range is Long_Float
       range Numerator_Range'First / Denominator_Range'Last ..
@@ -217,11 +217,11 @@ is
 
       R := Log10 (N / D);
 
-      --  The values in this assumption were generated using Wolfram|Alpha
-      --  based on the range of the Division_Result_Range subtype.
+      --  The values in this assumption are based on the mathemtical min/max
+      --  values of Log10 based on the possible range of the input: N / D.
       pragma Assume
-        (R in -9.63294660753049941556870873755718228673899250555249187993
-         .. 10.11006786225016185286373664081229759593912136974318774476,
+        (R in -7.22450781219257524826183006241290354369191576604307340090
+         .. 9.632946607530499415568708737557182286738992505552491879931,
          "The possible output range of log10, for the possible input range");
 
       if Use_16MHz_PRF then

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -99,7 +99,7 @@ is
 
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
                                   RXPACC        : in RX_FINFO_RXPACC_Field;
-                                  CIR_PWR       : in Bits_16)
+                                  CIR_PWR       : in RX_FQUAL_CIR_PWR_Field)
                                   return Float
    is
       subtype Numerator_Range is Long_Float
@@ -163,8 +163,8 @@ is
 
    function First_Path_Signal_Power (Use_16MHz_PRF : in Boolean;
                                      F1            : in Bits_16;
-                                     F2            : in Bits_16;
-                                     F3            : in Bits_16;
+                                     F2            : in RX_FQUAL_FP_AMPL2_Field;
+                                     F3            : in RX_FQUAL_FP_AMPL3_Field;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)
                                      return Float
    is

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -174,7 +174,7 @@ is
 
 
    function First_Path_Signal_Power (Use_16MHz_PRF : in Boolean;
-                                     F1            : in Bits_16;
+                                     F1            : in RX_TIME_FP_AMPL1_Field;
                                      F2            : in RX_FQUAL_FP_AMPL2_Field;
                                      F3            : in RX_FQUAL_FP_AMPL3_Field;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -30,7 +30,7 @@ is
 
 
    function Adjust_RXPACC (RXPACC              : in RX_FINFO_RXPACC_Field;
-                           RXPACC_NOSAT        : in Bits_16;
+                           RXPACC_NOSAT        : in RXPACC_NOSAT_Field;
                            RXBR                : in RX_FINFO_RXBR_Field;
                            SFD_LENGTH          : in Bits_8;
                            Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field
@@ -38,7 +38,7 @@ is
       RXPACC_Adjustment : RX_FINFO_RXPACC_Field;
 
    begin
-      if Bits_16 (RXPACC) = RXPACC_NOSAT then
+      if RXPACC_NOSAT_Field (RXPACC) = RXPACC_NOSAT then
          if Non_Standard_SFD then
             --  DecaWave-defined SFD sequence is used
             if RXBR = Data_Rate_110K then

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -108,6 +108,8 @@ is
       subtype Denominator_Range is Long_Float
       range 1.0 .. (2.0**12 - 1.0)**2;
 
+      type RXPACC_Sq_Range is range 0 .. RX_FINFO_RXPACC_Field'Last**2;
+
       N   : Numerator_Range;
       D   : Denominator_Range;
       A   : Long_Float;
@@ -140,7 +142,7 @@ is
       pragma Assert_And_Cut (N in Numerator_Range);
 
       if RXPACC /= 0 then
-         D := Long_Float (Bits_24 (RXPACC) * Bits_24 (RXPACC));
+         D := Long_Float (RXPACC_Sq_Range (RXPACC) * RXPACC_Sq_Range (RXPACC));
 
          pragma Assert (D in Denominator_Range);
       else
@@ -188,10 +190,17 @@ is
       subtype Denominator_Range is Long_Float
       range 1.0 .. (2.0**12 - 1.0)**2;
 
-      N   : Numerator_Range;
-      D   : Denominator_Range;
-      R   : Long_Float;
-      A   : Long_Float;
+      type AMPL_Sq_Range is range 0 .. (2**16 - 1)**2;
+
+      type AMPL_Sum_Range is range 0 .. AMPL_Sq_Range'Last * 3;
+
+      type RXPACC_Sq_Range is range 0 .. RX_FINFO_RXPACC_Field'Last**2;
+
+      F_Sum : AMPL_Sum_Range;
+      N     : Numerator_Range;
+      D     : Denominator_Range;
+      R     : Long_Float;
+      A     : Long_Float;
    begin
       --  Calculation from the DW1000 User Manual for the receive signal power
       --  is as follows:
@@ -208,9 +217,11 @@ is
       --    * A is 113.77 for a 16 MHz PRF or 121.74 for a 64 MHz PRF
 
       if F1 /= 0 or F2 /= 0 or F3 /= 0 then
-         N := Numerator_Range (Bits_33 (Bits_32 (F1) * Bits_32 (F1)) +
-                               Bits_33 (Bits_32 (F2) * Bits_32 (F2)) +
-                               Bits_33 (Bits_32 (F3) * Bits_32 (F3)));
+         F_Sum := (AMPL_Sum_Range (AMPL_Sq_Range (F1) * AMPL_Sq_Range (F1))
+                   + AMPL_Sum_Range (AMPL_Sq_Range (F2) * AMPL_Sq_Range (F2))
+                   + AMPL_Sum_Range (AMPL_Sq_Range (F3) * AMPL_Sq_Range (F3)));
+
+         N := Numerator_Range (F_Sum);
 
          pragma Assert (N in Numerator_Range);
       else
@@ -222,7 +233,7 @@ is
       pragma Assert_And_Cut (N in Numerator_Range);
 
       if RXPACC /= 0 then
-         D := Denominator_Range (Bits_24 (RXPACC) * Bits_24 (RXPACC));
+         D := Denominator_Range (RXPACC_Sq_Range (RXPACC) * RXPACC_Sq_Range (RXPACC));
 
          pragma Assert (D in Denominator_Range);
       else

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -255,19 +255,16 @@ is
    end First_Path_Signal_Power;
 
 
-   function Transmitter_Clock_Offset (RXTOFS  : in Bits_19;
+   function Transmitter_Clock_Offset (RXTOFS  : in RX_TTCKO_RXTOFS_Field;
                                       RXTTCKI : in RX_TTCKI_RXTTCKI_Field)
                                       return Long_Float
    is
       Offset   : Long_Float;
       Interval : Long_Float;
    begin
-      --  RXTOFS is a 19-bit signed quantity. The MSB is the sign bit.
-      if RXTOFS < 2**18 then
-         --  Positive quantity
+      if RXTOFS > -2**18 then
          Offset := Long_Float (RXTOFS);
-
-      elsif RXTOFS = 2**18 then
+      else
          --  Special case for the most negative number
          --  (closest to negative infinity).
          --  Normally, this value would indicate -2.0**18, however, we must
@@ -277,14 +274,11 @@ is
          --  If Offset is allowed to have the value -2.0**18 then it is not
          --  possible for GNATprove to prove that Offset / Interval >= -1.0
          --  (presumably the rounding may cause the proof to fail for -1.0)
-         Offset := -(2.0**18 - 1.0);
 
-      else
-         --  Negative quantity
-         Offset := -Long_Float ((not RXTOFS) + 1);
-
-         pragma Assert (Offset >= -(2.0**18 - 1.0) and Offset <= -1.0);
+         Offset := -2.0**18 + 1.0;
       end if;
+
+      pragma Assert_And_Cut (Offset in -2.0**18 + 1.0 .. 2.0**18 - 1.0);
 
       --  RXTTCKI takes one of two values (Section 7.2.21 of the User Manual):
       --     16#01F00000# for a 16 MHz PRF

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -108,6 +108,8 @@ is
       subtype Denominator_Range is Long_Float
       range 1.0 .. (2.0**12 - 1.0)**2;
 
+      type CIR_PWR_Range is range 0 .. (2**16 - 1) * 2**17;
+
       type RXPACC_Sq_Range is range 0 .. RX_FINFO_RXPACC_Field'Last**2;
 
       N   : Numerator_Range;
@@ -128,7 +130,7 @@ is
       --    * A is 113.77 for a 16 MHz PRF or 121.74 for a 64 MHz PRF
 
       if CIR_PWR /= 0 then
-         N := Long_Float (Bits_33 (CIR_PWR) * 2**17);
+         N := Long_Float (CIR_PWR_Range (CIR_PWR) * 2**17);
 
          pragma Assert (N in Numerator_Range);
       else

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -21,6 +21,7 @@
 -------------------------------------------------------------------------------
 
 with Ada.Numerics.Generic_Elementary_Functions;
+with DW1000.Register_Types;                     use DW1000.Register_Types;
 with Interfaces;                                use Interfaces;
 
 package body DW1000.Reception_Quality
@@ -28,19 +29,19 @@ with SPARK_Mode => On
 is
 
 
-   function Adjust_RXPACC (RXPACC              : in Bits_12;
+   function Adjust_RXPACC (RXPACC              : in RX_FINFO_RXPACC_Field;
                            RXPACC_NOSAT        : in Bits_16;
-                           RXBR                : in Bits_2;
+                           RXBR                : in RX_FINFO_RXBR_Field;
                            SFD_LENGTH          : in Bits_8;
-                           Non_Standard_SFD    : in Boolean) return Bits_12
+                           Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field
    is
-      RXPACC_Adjustment : Bits_12;
+      RXPACC_Adjustment : RX_FINFO_RXPACC_Field;
 
    begin
       if Bits_16 (RXPACC) = RXPACC_NOSAT then
          if Non_Standard_SFD then
             --  DecaWave-defined SFD sequence is used
-            if RXBR = 2#00# then
+            if RXBR = Data_Rate_110K then
                --  110 kbps data rate. SFD length is always 64 symbols
                RXPACC_Adjustment := 82;
             else
@@ -50,7 +51,7 @@ is
 
          else
             --  Standard-defined SFD sequence is used
-            if RXBR = 2#00# then
+            if RXBR = Data_Rate_110K then
                -- 110 kbps data rate. SFD length is always 64 symbols
                RXPACC_Adjustment := 64;
             else
@@ -97,7 +98,7 @@ is
 
 
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
-                                  RXPACC        : in Bits_12;
+                                  RXPACC        : in RX_FINFO_RXPACC_Field;
                                   CIR_PWR       : in Bits_16)
                                   return Float
    is
@@ -164,7 +165,8 @@ is
                                      F1            : in Bits_16;
                                      F2            : in Bits_16;
                                      F3            : in Bits_16;
-                                     RXPACC        : in Bits_12) return Float
+                                     RXPACC        : in RX_FINFO_RXPACC_Field)
+                                     return Float
    is
       subtype F_Range is Long_Float range 0.0 .. (2.0**16 - 1.0)**2;
 

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -114,7 +114,7 @@ is
    --     is -218.07 dBm to -12.67 dBm.
 
 
-   function Transmitter_Clock_Offset (RXTOFS  : in Bits_19;
+   function Transmitter_Clock_Offset (RXTOFS  : in RX_TTCKO_RXTOFS_Field;
                                       RXTTCKI : in RX_TTCKI_RXTTCKI_Field)
                                       return Long_Float
      with Post => Transmitter_Clock_Offset'Result in -1.0 .. 1.0;

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -67,7 +67,7 @@ is
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
                                   RXPACC        : in RX_FINFO_RXPACC_Field;
                                   CIR_PWR       : in Bits_16) return Float
-     with Post => Receive_Signal_Power'Result in -166.90 .. -14.43;
+     with Post => Receive_Signal_Power'Result in -142.81 .. -14.43;
    --  Compute the estimated receive signal power in dBm.
    --
    --  @param Use_16MHz_PRF Set to True if a 16 MHz PRF is used, otherwise set
@@ -91,7 +91,7 @@ is
                                      F3            : in Bits_16;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)
                                      return Float
-     with Post => First_Path_Signal_Power'Result in -218.07 .. -12.66;
+     with Post => First_Path_Signal_Power'Result in -193.99 .. -17.44;
    --  Compute the estimated first path power level in dBm.
    --
    --  @param Use_16MHz_PRF Set to True if a 16 MHz PRF is used, otherwise set

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -66,7 +66,8 @@ is
 
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
                                   RXPACC        : in RX_FINFO_RXPACC_Field;
-                                  CIR_PWR       : in Bits_16) return Float
+                                  CIR_PWR       : in RX_FQUAL_CIR_PWR_Field)
+                                  return Float
      with Post => Receive_Signal_Power'Result in -142.81 .. -14.43;
    --  Compute the estimated receive signal power in dBm.
    --
@@ -87,8 +88,8 @@ is
 
    function First_Path_Signal_Power (Use_16MHz_PRF : in Boolean;
                                      F1            : in Bits_16;
-                                     F2            : in Bits_16;
-                                     F3            : in Bits_16;
+                                     F2            : in RX_FQUAL_FP_AMPL2_Field;
+                                     F3            : in RX_FQUAL_FP_AMPL3_Field;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)
                                      return Float
      with Post => First_Path_Signal_Power'Result in -193.99 .. -17.44;

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -115,7 +115,8 @@ is
 
 
    function Transmitter_Clock_Offset (RXTOFS  : in Bits_19;
-                                      RXTTCKI : in Bits_32) return Long_Float
+                                      RXTTCKI : in RX_TTCKI_RXTTCKI_Field)
+                                      return Long_Float
      with Post => Transmitter_Clock_Offset'Result in -1.0 .. 1.0;
    --  Calculate the clock offset between the receiver's and transmitter's
    --  clocks.

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -20,7 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
-with DW1000.Types; use DW1000.Types;
+with DW1000.Register_Types; use DW1000.Register_Types;
+with DW1000.Types;          use DW1000.Types;
 
 --  @summary
 --  Utility functions for measuring the quality of received frames.
@@ -28,12 +29,12 @@ package DW1000.Reception_Quality
 with SPARK_Mode => On
 is
 
-   function Adjust_RXPACC (RXPACC              : in Bits_12;
+   function Adjust_RXPACC (RXPACC              : in RX_FINFO_RXPACC_Field;
                            RXPACC_NOSAT        : in Bits_16;
-                           RXBR                : in Bits_2;
+                           RXBR                : in RX_FINFO_RXBR_Field;
                            SFD_LENGTH          : in Bits_8;
-                           Non_Standard_SFD    : in Boolean) return Bits_12
-     with Pre => (RXBR /= 2#11#
+                           Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field
+     with Pre => (RXBR /= Reserved
                   and (if Non_Standard_SFD then SFD_LENGTH in 8 | 16));
    --  Apply the correction to the RXPACC value.
    --
@@ -64,7 +65,7 @@ is
 
 
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
-                                  RXPACC        : in Bits_12;
+                                  RXPACC        : in RX_FINFO_RXPACC_Field;
                                   CIR_PWR       : in Bits_16) return Float
      with Post => Receive_Signal_Power'Result in -166.90 .. -14.43;
    --  Compute the estimated receive signal power in dBm.
@@ -88,7 +89,8 @@ is
                                      F1            : in Bits_16;
                                      F2            : in Bits_16;
                                      F3            : in Bits_16;
-                                     RXPACC        : in Bits_12) return Float
+                                     RXPACC        : in RX_FINFO_RXPACC_Field)
+                                     return Float
      with Post => First_Path_Signal_Power'Result in -218.07 .. -12.66;
    --  Compute the estimated first path power level in dBm.
    --

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -87,7 +87,7 @@ is
 
 
    function First_Path_Signal_Power (Use_16MHz_PRF : in Boolean;
-                                     F1            : in Bits_16;
+                                     F1            : in RX_TIME_FP_AMPL1_Field;
                                      F2            : in RX_FQUAL_FP_AMPL2_Field;
                                      F3            : in RX_FQUAL_FP_AMPL3_Field;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -30,7 +30,7 @@ with SPARK_Mode => On
 is
 
    function Adjust_RXPACC (RXPACC              : in RX_FINFO_RXPACC_Field;
-                           RXPACC_NOSAT        : in Bits_16;
+                           RXPACC_NOSAT        : in RXPACC_NOSAT_Field;
                            RXBR                : in RX_FINFO_RXBR_Field;
                            SFD_LENGTH          : in Bits_8;
                            Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -928,7 +928,7 @@ is
    -- TX_ANTD register file
 
    type TX_ANTD_Type is record
-      TX_ANTD : Types.Bits_16;
+      TX_ANTD : System_Time.Antenna_Delay_Time := 0.0;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1237,9 +1237,17 @@ is
    ----------------------------------------------------------------------------
    -- AGC_CTRL register file
 
-   -- AGC_CTRL1 sub-register
+   ------------------------------
+   --  AGC_CTRL1 sub-register  --
+   ------------------------------
+
+   type AGC_CTRL1_DIS_AM_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+
    type AGC_CTRL1_Type is record
-      DIS_AM : Types.Bits_1    := 1;
+      DIS_AM : AGC_CTRL1_DIS_AM_Field := Disabled;
 
       Reserved : Types.Bits_15 := 0;
    end record
@@ -1253,9 +1261,17 @@ is
       Reserved at 0 range 1 .. 15;
    end record;
 
-   -- AGC_TUNE1 sub-register
+   ------------------------------
+   --  AGC_TUNE1 sub-register  --
+   ------------------------------
+
+   type AGC_TUNE1_Field is new Bits_16;
+
+   AGC_TUNE1_PRF_16MHz : constant AGC_TUNE1_Field := 16#8870#;
+   AGC_TUNE1_PRF_64MHz : constant AGC_TUNE1_Field := 16#889B#;
+
    type AGC_TUNE1_Type is record
-      AGC_TUNE1 : Types.Bits_16;
+      AGC_TUNE1 : AGC_TUNE1_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -1265,9 +1281,16 @@ is
       AGC_TUNE1 at 0 range 0 .. 15;
    end record;
 
-   -- AGC_TUNE2 sub-register
+   ------------------------------
+   --  AGC_TUNE2 sub-register  --
+   ------------------------------
+
+   type AGC_TUNE2_Field is new Bits_32;
+
+   AGC_TUNE2_Value : constant AGC_TUNE2_Field := 16#2502A907#;
+
    type AGC_TUNE2_Type is record
-      AGC_TUNE2 : Types.Bits_32;
+      AGC_TUNE2 : AGC_TUNE2_Field;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -1277,9 +1300,16 @@ is
       AGC_TUNE2 at 0 range 0 .. 31;
    end record;
 
-   -- AGC_TUNE3 sub-register
+   ------------------------------
+   --  AGC_TUNE3 sub-register  --
+   ------------------------------
+
+   type AGC_TUNE3_Field is new Bits_16;
+
+   AGC_TUNE3_Value : constant AGC_TUNE3_Field := 16#0035#;
+
    type AGC_TUNE3_Type is record
-      AGC_TUNE3 : Types.Bits_16;
+      AGC_TUNE3 : AGC_TUNE3_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -1289,10 +1319,21 @@ is
       AGC_TUNE3 at 0 range 0 .. 15;
    end record;
 
-   -- AGC_STAT1 sub-register
+   ------------------------------
+   --  AGC_STAT1 sub-register  --
+   ------------------------------
+
+   type AGC_STAT1_EDG1_Field is range 0 .. 2**5 - 1
+     with Size => 5;
+   --  This 5-bit gain value relates to input noise power measurement.
+
+   type AGC_STAT1_EDV2_Field is range 0 .. 2**9 - 1
+     with Size => 9;
+   --  This 9-bit value relates to the input noise power measurement.
+
    type AGC_STAT1_Type is record
-      EDG1 : Types.Bits_5;
-      EDV2 : Types.Bits_9;
+      EDG1 : AGC_STAT1_EDG1_Field;
+      EDV2 : AGC_STAT1_EDV2_Field;
 
       Reserved_1 : Types.Bits_6;
       Reserved_2 : Types.Bits_4;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2016,9 +2016,21 @@ is
    ----------------------------------------------------------------------------
    -- DRX_CONF register file
 
-   -- DRX_TUNE0b sub-register
+   ------------------------------
+   -- DRX_TUNE0b sub-register  --
+   ------------------------------
+
+   type DRX_TUNE0b_Field is new Bits_16;
+
+   DRX_TUNE0b_110K_STD     : constant DRX_TUNE0b_Field := 16#000A#;
+   DRX_TUNE0b_110K_Non_STD : constant DRX_TUNE0b_Field := 16#0016#;
+   DRX_TUNE0b_850K_STD     : constant DRX_TUNE0b_Field := 16#0001#;
+   DRX_TUNE0b_850K_Non_STD : constant DRX_TUNE0b_Field := 16#0006#;
+   DRX_TUNE0b_6M8_STD      : constant DRX_TUNE0b_Field := 16#0001#;
+   DRX_TUNE0b_6M8_Non_STD  : constant DRX_TUNE0b_Field := 16#0002#;
+
    type DRX_TUNE0b_Type is record
-      DRX_TUNE0b : Types.Bits_16;
+      DRX_TUNE0b : DRX_TUNE0b_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2028,9 +2040,17 @@ is
       DRX_TUNE0b at 0 range 0 .. 15;
    end record;
 
-   -- DRX_TUNE1a sub-register
+   ------------------------------
+   -- DRX_TUNE1a sub-register  --
+   ------------------------------
+
+   type DRX_TUNE1a_Field is new Bits_16;
+
+   DRX_TUNE1a_16MHz : constant DRX_TUNE1a_Field := 16#0087#;
+   DRX_TUNE1a_64MHz : constant DRX_TUNE1a_Field := 16#008D#;
+
    type DRX_TUNE1a_Type is record
-      DRX_TUNE1a : Types.Bits_16;
+      DRX_TUNE1a : DRX_TUNE1a_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2040,9 +2060,23 @@ is
       DRX_TUNE1a at 0 range 0 .. 15;
    end record;
 
-   -- DRX_TUNE1b sub-register
+   ------------------------------
+   -- DRX_TUNE1b sub-register  --
+   ------------------------------
+
+   type DRX_TUNE1b_Field is new Bits_16;
+
+   DRX_TUNE1b_110K     : constant DRX_TUNE1b_Field := 16#0064#;
+   --  Preamble lengths > 1024 symbols, for 110 kbps operation
+
+   DRX_TUNE1b_850K_6M8 : constant DRX_TUNE1b_Field := 16#0020#;
+   -- Preamble lengths 128 to 1024 symbols, for 850 kbps and 6.8 Mbps operation
+
+   DRX_TUNE1b_6M8      : constant DRX_TUNE1b_Field := 16#0010#;
+   --  Preamble length = 64 symbols, for 6.8 Mbps operation
+
    type DRX_TUNE1b_Type is record
-      DRX_TUNE1b : Types.Bits_16;
+      DRX_TUNE1b : DRX_TUNE1b_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2052,9 +2086,23 @@ is
       DRX_TUNE1b at 0 range 0 .. 15;
    end record;
 
-   -- DRX_TUNE2 sub-register
+   ------------------------------
+   -- DRX_TUNE2 sub-register  --
+   ------------------------------
+
+   type DRX_TUNE2_Field is new Bits_32;
+
+   DRX_TUNE2_PAC8_16MHz  : constant DRX_TUNE2_Field := 16#311A002D#;
+   DRX_TUNE2_PAC8_64MHz  : constant DRX_TUNE2_Field := 16#313B006B#;
+   DRX_TUNE2_PAC16_16MHz : constant DRX_TUNE2_Field := 16#331A0052#;
+   DRX_TUNE2_PAC16_64MHz : constant DRX_TUNE2_Field := 16#333B00BE#;
+   DRX_TUNE2_PAC32_16MHz : constant DRX_TUNE2_Field := 16#351A009A#;
+   DRX_TUNE2_PAC32_64MHz : constant DRX_TUNE2_Field := 16#353B015E#;
+   DRX_TUNE2_PAC64_16MHz : constant DRX_TUNE2_Field := 16#371A011D#;
+   DRX_TUNE2_PAC64_64MHz : constant DRX_TUNE2_Field := 16#373B0296#;
+
    type DRX_TUNE2_Type is record
-      DRX_TUNE2 : Types.Bits_32;
+      DRX_TUNE2 : DRX_TUNE2_Field;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -2064,9 +2112,16 @@ is
       DRX_TUNE2 at 0 range 0 .. 31;
    end record;
 
-   -- DRX_SFDTOC sub-register
+   ------------------------------
+   -- DRX_SFDTOC sub-register  --
+   ------------------------------
+
+   type DRX_SFDTOC_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  SFD detection timeout count (in units of preamble symbols)
+
    type DRX_SFDTOC_Type is record
-      DRX_SFDTOC : Types.Bits_16;
+      DRX_SFDTOC : DRX_SFDTOC_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2076,9 +2131,16 @@ is
       DRX_SFDTOC at 0 range 0 .. 15;
    end record;
 
-   -- DRX_PRETOC sub-register
+   ------------------------------
+   -- DRX_PRETOC sub-register  --
+   ------------------------------
+
+   type DRX_PRETOC_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  Preamble detection timeout count (in units of PAC size symbols)
+
    type DRX_PRETOC_Type is record
-      DRX_PRETOC : Types.Bits_16;
+      DRX_PRETOC : DRX_PRETOC_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2088,9 +2150,17 @@ is
       DRX_PRETOC at 0 range 0 .. 15;
    end record;
 
-   -- DRX_TUNE4H sub-register
+   ------------------------------
+   -- DRX_TUNE4H sub-register  --
+   ------------------------------
+
+   type DRX_TUNE4H_Field is new Bits_16;
+
+   DRX_TUNE4H_Preamble_64 : constant DRX_TUNE4H_Field := 16#0010#; --  64
+   DRX_TUNE4H_Others      : constant DRX_TUNE4H_Field := 16#0028#; --  128 or greater
+
    type DRX_TUNE4H_Type is record
-      DRX_TUNE4H : Types.Bits_16;
+      DRX_TUNE4H : DRX_TUNE4H_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2100,9 +2170,15 @@ is
       DRX_TUNE4H at 0 range 0 .. 15;
    end record;
 
-   -- RXPACC_NOSAT sub-register
+   --------------------------------
+   -- RXPACC_NOSAT sub-register  --
+   --------------------------------
+
+   type RXPACC_NOSAT_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+
    type RXPACC_NOSAT_Type is record
-      RXPACC_NOSAT : Types.Bits_16;
+      RXPACC_NOSAT : RXPACC_NOSAT_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -912,8 +912,8 @@ is
    -- TX_TIME register file
 
    type TX_TIME_Type is record
-      TX_STAMP : Types.Bits_40 := 0;
-      TX_RAWST : Types.Bits_40 := 0;
+      TX_STAMP : System_Time.Fine_System_Time   := 0.0;
+      TX_RAWST : System_Time.Coarse_System_Time := 0.0;
    end record
      with Size => 80,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1046,9 +1046,13 @@ is
    ----------------------------------------------------------------------------
    -- ACK_RESP_T register file
 
+   type ACK_RESP_T_ACK_TIM_Field is range 0 .. 255
+     with Size => 8;
+   --  Auto-Acknowledgement turn-around Time (in number of preamble symbols).
+
    type ACK_RESP_T_Type is record
-      W4D_TIM : Types.Bits_20 := 0;
-      ACK_TIM : Types.Bits_8  := 0;
+      W4D_TIM : System_Time.Response_Wait_Timeout_Time := 0.0;
+      ACK_TIM : ACK_RESP_T_ACK_TIM_Field               := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1154,15 +1154,51 @@ is
    ----------------------------------------------------------------------------
    -- CHAN_CTRL register file
 
+   type CHAN_CTRL_Channel_Field is range 0 .. 15
+     with Size => 4;
+   --  This selects the transmit/receive channel.
+
+   type CHAN_CTRL_DWSFD_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit enables a non-standard Decawave proprietary SFD sequence.
+
+   type CHAN_CTRL_RXPRF_Field is
+     (Reserved_00,
+      PRF_16MHz,
+      PRF_64MHz,
+      Reserved_11)
+     with Size => 2;
+   --  This two bit field selects the PRF used in the receiver.
+
+   type CHAN_CTRL_TNSSFD_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit enables the use of a user specified (non-standard) SFD in the
+   --  transmitter.
+
+   type CHAN_CTRL_RNSSFD_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit enables the use of a user specified (non-standard) SFD in the
+   --  receiver.
+
+   type CHAN_CTRL_PCODE_Field is range 0 .. 31
+     with Size => 5;
+   --  This field selects the preamble code used in the transmitter/receiver.
+
    type CHAN_CTRL_Type is record
-      TX_CHAN  : Types.Bits_4 := 5;
-      RX_CHAN  : Types.Bits_4 := 5;
-      DWSFD    : Types.Bits_1 := 0;
-      RXPRF    : Types.Bits_2 := 0;
-      TNSSFD   : Types.Bits_1 := 0;
-      RNSSFD   : Types.Bits_1 := 0;
-      TX_PCODE : Types.Bits_5 := 0;
-      RX_PCODE : Types.Bits_5 := 0;
+      TX_CHAN  : CHAN_CTRL_Channel_Field := 5;
+      RX_CHAN  : CHAN_CTRL_Channel_Field := 5;
+      DWSFD    : CHAN_CTRL_DWSFD_Field   := Disabled;
+      RXPRF    : CHAN_CTRL_RXPRF_Field   := Reserved_00;
+      TNSSFD   : CHAN_CTRL_TNSSFD_Field  := Disabled;
+      RNSSFD   : CHAN_CTRL_RNSSFD_Field  := Disabled;
+      TX_PCODE : CHAN_CTRL_PCODE_Field   := 0;
+      RX_PCODE : CHAN_CTRL_PCODE_Field   := 0;
 
       Reserved : Types.Bits_9 := 0;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -520,35 +520,41 @@ is
    ----------------------------------------------------------------------------
    -- SYS_MASK register file
 
+   type SYS_MASK_Mask_Field is
+     (Masked,
+      Not_Masked)
+     with Size => 1;
+   --  Mask event.
+
    type SYS_MASK_Type is record
-      MCPLOCK   : Types.Bits_1  := 0;
-      MESYNCR   : Types.Bits_1  := 0;
-      MAAT      : Types.Bits_1  := 0;
-      MTXFRB    : Types.Bits_1  := 0;
-      MTXPRS    : Types.Bits_1  := 0;
-      MTXPHS    : Types.Bits_1  := 0;
-      MTXFRS    : Types.Bits_1  := 0;
-      MRXPRD    : Types.Bits_1  := 0;
-      MRXSFDD   : Types.Bits_1  := 0;
-      MLDEDONE  : Types.Bits_1  := 0;
-      MRXPHD    : Types.Bits_1  := 0;
-      MRXPHE    : Types.Bits_1  := 0;
-      MRXDFR    : Types.Bits_1  := 0;
-      MRXFCG    : Types.Bits_1  := 0;
-      MRXFCE    : Types.Bits_1  := 0;
-      MRXRFSL   : Types.Bits_1  := 0;
-      MRXRFTO   : Types.Bits_1  := 0;
-      MLDEERR   : Types.Bits_1  := 0;
-      MRXOVRR   : Types.Bits_1  := 0;
-      MRXPTO    : Types.Bits_1  := 0;
-      MGPIOIRQ  : Types.Bits_1  := 0;
-      MSLP2INIT : Types.Bits_1  := 0;
-      MRFPLLLL  : Types.Bits_1  := 0;
-      MCPLLLL   : Types.Bits_1  := 0;
-      MRXSFDTO  : Types.Bits_1  := 0;
-      MHPDWARN  : Types.Bits_1  := 0;
-      MTXBERR   : Types.Bits_1  := 0;
-      MAFFREJ   : Types.Bits_1  := 0;
+      MCPLOCK   : SYS_MASK_Mask_Field := Masked;
+      MESYNCR   : SYS_MASK_Mask_Field := Masked;
+      MAAT      : SYS_MASK_Mask_Field := Masked;
+      MTXFRB    : SYS_MASK_Mask_Field := Masked;
+      MTXPRS    : SYS_MASK_Mask_Field := Masked;
+      MTXPHS    : SYS_MASK_Mask_Field := Masked;
+      MTXFRS    : SYS_MASK_Mask_Field := Masked;
+      MRXPRD    : SYS_MASK_Mask_Field := Masked;
+      MRXSFDD   : SYS_MASK_Mask_Field := Masked;
+      MLDEDONE  : SYS_MASK_Mask_Field := Masked;
+      MRXPHD    : SYS_MASK_Mask_Field := Masked;
+      MRXPHE    : SYS_MASK_Mask_Field := Masked;
+      MRXDFR    : SYS_MASK_Mask_Field := Masked;
+      MRXFCG    : SYS_MASK_Mask_Field := Masked;
+      MRXFCE    : SYS_MASK_Mask_Field := Masked;
+      MRXRFSL   : SYS_MASK_Mask_Field := Masked;
+      MRXRFTO   : SYS_MASK_Mask_Field := Masked;
+      MLDEERR   : SYS_MASK_Mask_Field := Masked;
+      MRXOVRR   : SYS_MASK_Mask_Field := Masked;
+      MRXPTO    : SYS_MASK_Mask_Field := Masked;
+      MGPIOIRQ  : SYS_MASK_Mask_Field := Masked;
+      MSLP2INIT : SYS_MASK_Mask_Field := Masked;
+      MRFPLLLL  : SYS_MASK_Mask_Field := Masked;
+      MCPLLLL   : SYS_MASK_Mask_Field := Masked;
+      MRXSFDTO  : SYS_MASK_Mask_Field := Masked;
+      MHPDWARN  : SYS_MASK_Mask_Field := Masked;
+      MTXBERR   : SYS_MASK_Mask_Field := Masked;
+      MAFFREJ   : SYS_MASK_Mask_Field := Masked;
 
       Reserved_1 : Types.Bits_1 := 0;
       Reserved_2 : Types.Bits_1 := 0;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2191,12 +2191,35 @@ is
    ----------------------------------------------------------------------------
    -- RF_CONF register file
 
-   -- RF_CONF sub-register
+   ---------------------------
+   -- RF_CONF sub-register  --
+   ---------------------------
+
+   type RF_CONF_TXFEN_Field is new Bits_5;
+   --  Transmit block force enable.
+
+   RF_CONF_TXFEN_Force_Enable : constant RF_CONF_TXFEN_Field := 16#1F#;
+
+   type RF_CONF_PLLFEN_Field is new Bits_3;
+   --  PLL block force enables.
+
+   RF_CONF_PLLFEN_Force_Enable : constant RF_CONF_PLLFEN_Field := 16#5#;
+
+   type RF_CONF_LDOFEN_Field is new Bits_5;
+   --  Write 0x1F to force the enable to all LDOs.
+
+   RF_CONF_LDOFEN_Force_Enable : constant RF_CONF_LDOFEN_Field := 16#1F#;
+
+   type RF_CONF_TXRXSW_Field is new Bits_2;
+
+   RF_CONF_TXRXSW_Force_Tx : constant RF_CONF_TXRXSW_Field := 16#2#;
+   RF_CONF_TXRXSW_Force_Rx : constant RF_CONF_TXRXSW_Field := 16#1#;
+
    type RF_CONF_Type is record
-      TXFEN  : Types.Bits_5 := 0;
-      PLLFEN : Types.Bits_3 := 0;
-      LDOFEN : Types.Bits_5 := 0;
-      TXRXSW : Types.Bits_2 := 0;
+      TXFEN  : RF_CONF_TXFEN_Field  := 0;
+      PLLFEN : RF_CONF_PLLFEN_Field := 0;
+      LDOFEN : RF_CONF_LDOFEN_Field := 0;
+      TXRXSW : RF_CONF_TXRXSW_Field := 0;
 
       Reserved_1 : Types.Bits_8 := 0;
       Reserved_2 : Types.Bits_9 := 0;
@@ -2216,9 +2239,17 @@ is
       Reserved_2 at 0 range 23 .. 31;
    end record;
 
-   -- RF_RXCTRLH sub-register
+   ------------------------------
+   -- RF_RXCTRLH sub-register  --
+   ------------------------------
+
+   type RF_RXCTRLH_Field is new Bits_8;
+
+   RF_RXCTRLH_500MHz : constant RF_RXCTRLH_Field := 16#D8#; --  Channels 1,2,3,5
+   RF_RXCTRLH_900MHz : constant RF_RXCTRLH_Field := 16#BC#; --  Channels 4,7
+
    type RF_RXCTRLH_Type is record
-      RF_RXCTRLH : Types.Bits_8;
+      RF_RXCTRLH : RF_RXCTRLH_Field;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -2228,9 +2259,21 @@ is
       RF_RXCTRLH at 0 range 0 .. 7;
    end record;
 
-   -- RF_TXCTRL sub-register
+   -----------------------------
+   -- RF_TXCTRL sub-register  --
+   -----------------------------
+
+   type RF_TXCTRL_Field is new Bits_32;
+
+   RF_TXCTRL_Channel_1 : constant RF_TXCTRL_Field := 16#00005C40#;
+   RF_TXCTRL_Channel_2 : constant RF_TXCTRL_Field := 16#00045CA0#;
+   RF_TXCTRL_Channel_3 : constant RF_TXCTRL_Field := 16#00086CC0#;
+   RF_TXCTRL_Channel_4 : constant RF_TXCTRL_Field := 16#00045C80#;
+   RF_TXCTRL_Channel_5 : constant RF_TXCTRL_Field := 16#001E3FE3#;
+   RF_TXCTRL_Channel_7 : constant RF_TXCTRL_Field := 16#001E7DE0#;
+
    type RF_TXCTRL_Type is record
-      RF_TXCTRL : Types.Bits_32 := 16#001E_3DE0#;
+      RF_TXCTRL : RF_TXCTRL_Field;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -2240,12 +2283,39 @@ is
       RF_TXCTRL at 0 range 0 .. 31;
    end record;
 
-   -- RF_STATUS sub-register
+   -----------------------------
+   -- RF_STATUS sub-register  --
+   -----------------------------
+
+   type RF_STATUS_CPLLLOCK_Field is
+     (Not_Locked,
+      Locked)
+     with Size => 1;
+   --  Clock PLL Lock status.
+
+   type RF_STATUS_CPLLLOW_Field is
+     (Not_Low,
+      Low)
+     with Size => 1;
+   --  Clock PLL Low flag status.
+
+   type RF_STATUS_CPLLHIGH_Field is
+     (Not_High,
+      High)
+     with Size => 1;
+   --  Clock PLL High flag status.
+
+   type RF_STATUS_RFPLLLOCK_Field is
+     (Not_Locked,
+      Locked)
+     with Size => 1;
+   --  RF PLL Lock status.
+
    type RF_STATUS_Type is record
-      CPLLLOCK  : Types.Bits_1 := 0;
-      CPLLLOW   : Types.Bits_1 := 0;
-      CPLLHIGH  : Types.Bits_1 := 0;
-      RFPLLLOCK : Types.Bits_1 := 0;
+      CPLLLOCK  : RF_STATUS_CPLLLOCK_Field  := Not_Locked;
+      CPLLLOW   : RF_STATUS_CPLLLOW_Field   := Not_Low;
+      CPLLHIGH  : RF_STATUS_CPLLHIGH_Field  := Not_High;
+      RFPLLLOCK : RF_STATUS_RFPLLLOCK_Field := Not_Locked;
 
       Reserved  : Types.Bits_4 := 0;
    end record
@@ -2262,9 +2332,14 @@ is
       Reserved  at 0 range 4 .. 7;
    end record;
 
-   -- LDOTUNE sub-register
+   ---------------------------
+   -- LDOTUNE sub-register  --
+   ---------------------------
+
+   type LDOTUNE_Field is new Bits_40;
+
    type LDOTUNE_Type is Record
-      LDOTUNE : Types.Bits_40 := 16#88_8888_8888#;
+      LDOTUNE : LDOTUNE_Field := 16#88_8888_8888#;
    end record
      with Size => 40,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -3285,10 +3285,25 @@ is
    ----------------------------------------------------------------------------
    -- DIG_DIAG register file
 
-   -- EVC_CTRL sub-register
+   ----------------------------
+   -- EVC_CTRL sub-register  --
+   ----------------------------
+
+   type EVC_CTRL_EVC_EN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Event Counters Enable.
+
+   type EVC_CTRL_EVC_CLR_Field is
+     (No_action,
+      Clear_Counters)
+     with Size => 1;
+   --  Event Counters Clear.
+
    type EVC_CTRL_Type is record
-      EVC_EN  : Types.Bits_1   := 0;
-      EVC_CLR : Types.Bits_1   := 0;
+      EVC_EN  : EVC_CTRL_EVC_EN_Field  := Disabled;
+      EVC_CLR : EVC_CTRL_EVC_CLR_Field := No_Action;
 
       Reserved : Types.Bits_30 := 0;
    end record
@@ -3303,9 +3318,16 @@ is
       Reserved at 0 range 2 .. 31;
    end record;
 
-   -- EVC_PHE sub-register
+   ---------------------------
+   -- EVC_PHE sub-register  --
+   ---------------------------
+
+   type EVC_Counter_Field is range 0 .. 2**12 - 1
+     with Size => 12;
+   --  Event counter field
+
    type EVC_PHE_Type is record
-      EVC_PHE : Types.Bits_12 := 0;
+      EVC_PHE : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3319,9 +3341,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_RSE sub-register
+   ---------------------------
+   -- EVC_RSE sub-register  --
+   ---------------------------
+
    type EVC_RSE_Type is record
-      EVC_RSE : Types.Bits_12 := 0;
+      EVC_RSE : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3335,9 +3360,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_FCG sub-register
+   ---------------------------
+   -- EVC_FCG sub-register  --
+   ---------------------------
+
    type EVC_FCG_Type is record
-      EVC_FCG : Types.Bits_12 := 0;
+      EVC_FCG : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3351,9 +3379,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_FCE sub-register
+   ---------------------------
+   -- EVC_FCE sub-register  --
+   ---------------------------
+
    type EVC_FCE_Type is record
-      EVC_FCE : Types.Bits_12 := 0;
+      EVC_FCE : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3367,9 +3398,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_FFR sub-register
+   ---------------------------
+   -- EVC_FFR sub-register  --
+   ---------------------------
+
    type EVC_FFR_Type is record
-      EVC_FFR : Types.Bits_12 := 0;
+      EVC_FFR : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3383,9 +3417,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_OVR sub-register
+   ---------------------------
+   -- EVC_OVR sub-register  --
+   ---------------------------
+
    type EVC_OVR_Type is record
-      EVC_OVR : Types.Bits_12 := 0;
+      EVC_OVR : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3399,9 +3436,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_STO sub-register
+   ---------------------------
+   -- EVC_STO sub-register  --
+   ---------------------------
+
    type EVC_STO_Type is record
-      EVC_STO : Types.Bits_12 := 0;
+      EVC_STO : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3415,9 +3455,11 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_PTO sub-register
+   ---------------------------
+   -- EVC_PTO sub-register  --
+   ---------------------------
    type EVC_PTO_Type is record
-      EVC_PTO : Types.Bits_12 := 0;
+      EVC_PTO : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3431,9 +3473,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_FWTO sub-register
+   ----------------------------
+   -- EVC_FWTO sub-register  --
+   ----------------------------
+
    type EVC_FWTO_Type is record
-      EVC_FWTO : Types.Bits_12 := 0;
+      EVC_FWTO : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3447,9 +3492,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_TXFS sub-register
+   ----------------------------
+   -- EVC_TXFS sub-register  --
+   ----------------------------
+
    type EVC_TXFS_Type is record
-      EVC_TXFS : Types.Bits_12 := 0;
+      EVC_TXFS : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3463,9 +3511,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_HPW sub-register
+   ---------------------------
+   -- EVC_HPW sub-register  --
+   ---------------------------
+
    type EVC_HPW_Type is record
-      EVC_HPW : Types.Bits_12 := 0;
+      EVC_HPW : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4 := 0;
    end record
@@ -3479,9 +3530,12 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- EVC_TPW sub-register
+   ---------------------------
+   -- EVC_TPW sub-register  --
+   ---------------------------
+
    type EVC_TPW_Type is record
-      EVC_TPW : Types.Bits_12;
+      EVC_TPW : EVC_Counter_Field := 0;
 
       Reserved : Types.Bits_4;
    end record
@@ -3495,9 +3549,18 @@ is
       Reserved at 0 range 12 .. 15;
    end record;
 
-   -- DIAG_TMC sub-register
+   ----------------------------
+   -- DIAG_TMC sub-register  --
+   ----------------------------
+
+   type DIAG_TMC_TX_PSTM_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Transmit Power Spectrum Test Mode.
+
    type DIAG_TMC_Type is record
-      TX_PSTM : Types.Bits_1 := 0;
+      TX_PSTM : DIAG_TMC_TX_PSTM_Field := Disabled;
 
       Reserved_1 : Types.Bits_4  := 0;
       Reserved_2 : Types.Bits_11 := 0;
@@ -3517,67 +3580,202 @@ is
    ----------------------------------------------------------------------------
    -- PMSC register file
 
+   type PMSC_CTRL0_SYSCLKS_Field is
+     (Auto,
+      Force_XTI,
+      Force_PLL,
+      Reserved)
+     with Size => 2;
+   --  System Clock Selection.
+
+   type PMSC_CTRL0_RXCLKS_Field is
+     (Auto,
+      Force_XTI,
+      Force_PLL,
+      Force_Off)
+     with Size => 2;
+   --  Receiver Clock Selection.
+
+   type PMSC_CTRL0_TXCLKS_Field is new PMSC_CTRL0_RXCLKS_Field;
+   --  Transmitter Clock Selection.
+
+   type PMSC_CTRL0_FACE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Force Accumulator Clock Enable.
+
+   type PMSC_CTRL0_ADCCE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  (temperature and voltage) Analog-to-Digital Convertor Clock Enable.
+
+   type PMSC_CTRL0_AMCE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Accumulator Memory Clock Enable.
+
+   type PMSC_CTRL0_GPCE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO clock Enable.
+
+   type PMSC_CTRL0_GPRN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO reset (NOT), active low.
+
+   type PMSC_CTRL0_GPDCE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO De-bounce Clock Enable.
+
+   type PMSC_CTRL0_GPDRN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO de-bounce reset (NOT), active low.
+
+   type PMSC_CTRL0_KHZCLKEN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Kilohertz clock Enable.
+
+   type PMSC_CTRL0_PLL2_SEQ_EN_Field is
+     (Normal,
+      Sniff)
+     with Size => 1;
+
+   type PMSC_CTRL0_SOFTRESET_Field is new Bits_4;
+   --  These four bits reset the IC TX, RX, Host Interface and the PMSC itself,
+   --  essentially allowing a reset of the IC under software control.
+
+   PMSC_CTRL0_SOFTRESET_Reset     : constant PMSC_CTRL0_SOFTRESET_Field := 2#0000#;
+   PMSC_CTRL0_SOFTRESET_Reset_Rx  : constant PMSC_CTRL0_SOFTRESET_Field := 2#0111#;
+   PMSC_CTRL0_SOFTRESET_Set_All   : constant PMSC_CTRL0_SOFTRESET_Field := 2#1111#;
+
    type PMSC_CTRL0_Type is record
-      SYSCLKS   : Types.Bits_2 := 0;
-      RXCLKS    : Types.Bits_2 := 0;
-      TXCLKS    : Types.Bits_2 := 0;
-      FACE      : Types.Bits_1 := 0;
-      ADCCE     : Types.Bits_1 := 0;
-      AMCE      : Types.Bits_1 := 0;
-      GPCE      : Types.Bits_1 := 0;
-      GPRN      : Types.Bits_1 := 0;
-      GPDCE     : Types.Bits_1 := 0;
-      GPDRN     : Types.Bits_1 := 0;
-      KHZCLKEN  : Types.Bits_1 := 0;
-      SOFTRESET : Types.Bits_4 := 2#1111#;
+      SYSCLKS     : PMSC_CTRL0_SYSCLKS_Field     := Auto;
+      RXCLKS      : PMSC_CTRL0_RXCLKS_Field      := Auto;
+      TXCLKS      : PMSC_CTRL0_TXCLKS_Field      := Auto;
+      FACE        : PMSC_CTRL0_FACE_Field        := Disabled;
+      ADCCE       : PMSC_CTRL0_ADCCE_Field       := Disabled;
+      AMCE        : PMSC_CTRL0_AMCE_Field        := Disabled;
+      GPCE        : PMSC_CTRL0_GPCE_Field        := Disabled;
+      GPRN        : PMSC_CTRL0_GPRN_Field        := Disabled;
+      GPDCE       : PMSC_CTRL0_GPDCE_Field       := Disabled;
+      GPDRN       : PMSC_CTRL0_GPDRN_Field       := Disabled;
+      KHZCLKEN    : PMSC_CTRL0_KHZCLKEN_Field    := Disabled;
+      PLL2_SEQ_EN : PMSC_CTRL0_PLL2_SEQ_EN_Field := Normal;
+      SOFTRESET   : PMSC_CTRL0_SOFTRESET_Field   := PMSC_CTRL0_SOFTRESET_Set_All;
 
       Reserved_1 : Types.Bits_3 := 2#100#;
       Reserved_2 : Types.Bits_4 := 0;
       Reserved_3 : Types.Bits_3 := 2#011#;
-      Reserved_4 : Types.Bits_4 := 0;
+      Reserved_4 : Types.Bits_3 := 0;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
      Scalar_Storage_Order => System.Low_Order_First;
 
    for PMSC_CTRL0_Type use record
-      SYSCLKS    at 0 range  0 ..  1;
-      RXCLKS     at 0 range  2 ..  3;
-      TXCLKS     at 0 range  4 ..  5;
-      FACE       at 0 range  6 ..  6;
+      SYSCLKS     at 0 range  0 ..  1;
+      RXCLKS      at 0 range  2 ..  3;
+      TXCLKS      at 0 range  4 ..  5;
+      FACE        at 0 range  6 ..  6;
 
-      Reserved_1 at 0 range  7 ..  9;
+      Reserved_1  at 0 range  7 ..  9;
 
-      ADCCE      at 0 range 10 .. 10;
+      ADCCE       at 0 range 10 .. 10;
 
-      Reserved_2 at 0 range 11 .. 14;
+      Reserved_2  at 0 range 11 .. 14;
 
-      AMCE       at 0 range 15 .. 15;
-      GPCE       at 0 range 16 .. 16;
-      GPRN       at 0 range 17 .. 17;
-      GPDCE      at 0 range 18 .. 18;
-      GPDRN      at 0 range 19 .. 19;
+      AMCE        at 0 range 15 .. 15;
+      GPCE        at 0 range 16 .. 16;
+      GPRN        at 0 range 17 .. 17;
+      GPDCE       at 0 range 18 .. 18;
+      GPDRN       at 0 range 19 .. 19;
 
-      Reserved_3 at 0 range 20 .. 22;
+      Reserved_3  at 0 range 20 .. 22;
 
-      KHZCLKEN   at 0 range 23 .. 23;
+      KHZCLKEN    at 0 range 23 .. 23;
+      PLL2_SEQ_EN at 0 range 24 .. 24;
 
-      Reserved_4 at 0 range 24 .. 27;
+      Reserved_4  at 0 range 25 .. 27;
 
-      SOFTRESET  at 0 range 28 .. 31;
+      SOFTRESET   at 0 range 28 .. 31;
    end record;
 
-   -- PMSC_CTRL1 sub-register
+   ------------------------------
+   -- PMSC_CTRL1 sub-register  --
+   ------------------------------
+
+   type PMSC_CTRL1_ARX2INIT_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Automatic transition from receive mode into the INIT state.
+
+   type PMSC_CTRL1_PKTSEQ_Field is new Bits_8;
+
+   PMSC_CTRL1_Disabled : constant PMSC_CTRL1_PKTSEQ_Field := 16#00#;
+   PMSC_CTRL1_Enabled  : constant PMSC_CTRL1_PKTSEQ_Field := 16#E7#;
+
+   type PMSC_CTRL1_ATXSLP_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  After TX automatically Sleep.
+
+   type PMSC_CTRL1_ARXSLP_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  After RX automatically Sleep.
+
+   type PMSC_CTRL1_SNOZE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Snooze Enable.
+
+   type PMSC_CTRL1_SNOZR_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Snooze Repeat.
+
+   type PMSC_CTRL1_PLLSYN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   -- This enables a special 1 GHz clock used for some external SYNC modes.
+
+   type PMSC_CTRL1_LDERUNE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  LDE run enable.
+
+   type PMSC_CTRL1_KHZCLKDIV_Field is range 0 .. 2**6 - 1
+     with Size => 6;
+
    type PMSC_CTRL1_Type is record
-      ARX2INIT  : Types.Bits_1 := 0;
-      PKTSEQ    : Types.Bits_8 := 2#1110_0111#;
-      ATXSLP    : Types.Bits_1 := 0;
-      ARXSLP    : Types.Bits_1 := 0;
-      SNOZE     : Types.Bits_1 := 0;
-      SNOZR     : Types.Bits_1 := 0;
-      PLLSYN    : Types.Bits_1 := 0;
-      LDERUNE   : Types.Bits_1 := 1;
-      KHZCLKDIV : Types.Bits_6 := 2#10_0000#;
+      ARX2INIT  : PMSC_CTRL1_ARX2INIT_Field  := Disabled;
+      PKTSEQ    : PMSC_CTRL1_PKTSEQ_Field    := PMSC_CTRL1_Enabled;
+      ATXSLP    : PMSC_CTRL1_ATXSLP_Field    := Disabled;
+      ARXSLP    : PMSC_CTRL1_ARXSLP_Field    := Disabled;
+      SNOZE     : PMSC_CTRL1_SNOZE_Field     := Disabled;
+      SNOZR     : PMSC_CTRL1_SNOZR_Field     := Disabled;
+      PLLSYN    : PMSC_CTRL1_PLLSYN_Field    := Disabled;
+      LDERUNE   : PMSC_CTRL1_LDERUNE_Field   := Enabled;
+      KHZCLKDIV : PMSC_CTRL1_KHZCLKDIV_Field := 32;
 
       Reserved_1 : Types.Bits_1 := 0;
       Reserved_2 : Types.Bits_1 := 0;
@@ -3611,9 +3809,12 @@ is
       KHZCLKDIV  at 0 range 26 .. 31;
    end record;
 
-   -- PMSC_SNOZT sub-register
+   ------------------------------
+   -- PMSC_SNOZT sub-register  --
+   ------------------------------
+
    type PMSC_SNOZT_Type is record
-      SNOZ_TIM : Types.Bits_8 := 2#0100_0000#;
+      SNOZ_TIM : System_Time.Snooze_Time := 0.001_706_667;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -3623,9 +3824,14 @@ is
       SNOZ_TIM at 0 range 0 .. 7;
    end record;
 
-   -- PMSC_TXFSEQ sub-register
+   -------------------------------
+   -- PMSC_TXFSEQ sub-register  --
+   -------------------------------
+
+   type PMSC_TXFSEQ_Field is new Bits_16;
+
    type PMSC_TXFSEQ_Type is record
-      TXFINESEQ : Types.Bits_16 := 2#0000_1011_0011_1100#;
+      TXFINESEQ : PMSC_TXFSEQ_Field := 2#0000_1011_0011_1100#;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3635,11 +3841,28 @@ is
       TXFINESEQ at 0 range 0 .. 15;
    end record;
 
-   -- PMSC_LEDC sub-register
+   -----------------------------
+   -- PMSC_LEDC sub-register  --
+   -----------------------------
+
+   type PMSC_LEDC_BLINKEN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Blink Enable.
+
+   type PMSC_LEDC_BLNKNOW_Field is
+     (No_Action,
+      Blink_Now)
+     with Size => 1;
+
    type PMSC_LEDC_Type is record
-      BLINK_TIM : Types.Bits_8 := 2#0010_0000#;
-      BLNKEN    : Types.Bits_1 := 0;
-      BLNKNOW   : Types.Bits_4 := 0;
+      BLINK_TIM       : System_Time.Blink_Time  := 0.448;
+      BLNKEN          : PMSC_LEDC_BLINKEN_Field := Disabled;
+      BLNKNOW_RXOKLED : PMSC_LEDC_BLNKNOW_Field := No_Action;
+      BLNKNOW_SFDLED  : PMSC_LEDC_BLNKNOW_Field := No_Action;
+      BLNKNOW_RXLED   : PMSC_LEDC_BLNKNOW_Field := No_Action;
+      BLNKNOW_TXLED   : PMSC_LEDC_BLNKNOW_Field := No_Action;
 
       Reserved_1 : Types.Bits_7  := 0;
       Reserved_2 : Types.Bits_12 := 0;
@@ -3649,14 +3872,17 @@ is
      Scalar_Storage_Order => System.Low_Order_First;
 
    for PMSC_LEDC_Type use record
-      BLINK_TIM  at 0 range 0 .. 7;
-      BLNKEN     at 0 range 8 .. 8;
+      BLINK_TIM        at 0 range 0 .. 7;
+      BLNKEN           at 0 range 8 .. 8;
 
-      Reserved_1 at 0 range 9 .. 15;
+      Reserved_1       at 0 range 9 .. 15;
 
-      BLNKNOW    at 0 range 16 .. 19;
+      BLNKNOW_RXOKLED  at 0 range 16 .. 16;
+      BLNKNOW_SFDLED   at 0 range 17 .. 17;
+      BLNKNOW_RXLED    at 0 range 18 .. 18;
+      BLNKNOW_TXLED    at 0 range 19 .. 19;
 
-      Reserved_2 at 0 range 20 .. 31;
+      Reserved_2       at 0 range 20 .. 31;
    end record;
 
 end DW1000.Register_Types;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -693,15 +693,60 @@ is
    ----------------------------------------------------------------------------
    -- RX_FINFO register file
 
+   type RX_FINFO_RXFLEN_Field is range 0 .. 127
+     with Size => 7;
+   --  Receive Frame Length.
+
+   type RX_FINFO_RXFLE_Field is range 0 .. 7
+     with Size => 3;
+   --  Receive Frame Length Extension.
+
+   type RX_FINFO_RXNSPL_Field is range 0 .. 3
+     with Size => 2;
+   --  Receive non-standard preamble length.
+
+   type RX_FINFO_RXBR_Field is
+     (Data_Rate_110K,
+      Data_Rate_850K,
+      Data_Rate_6M8,
+      Reserved)
+     with Size => 2;
+   --  Receive Bit Rate report.
+
+   type RX_FINFO_RNG_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Receiver Ranging.
+
+   type RX_FINFO_RXPRFR_Field is
+     (Reserved_00,
+      PRF_16MHz,
+      PRF_64MHz,
+      Reserved_11)
+     with Size => 2;
+   --  RX Pulse Repetition Rate report.
+
+   type RX_FINFO_RXPSR_Field is
+     (PLEN_16,
+      PLEN_64,
+      PLEN_1024,
+      PLEN_4096)
+     with Size => 2;
+   --  RX Preamble Repetition.
+
+   type RX_FINFO_RXPACC_Field is range 0 .. 2**12 - 1
+     with Size => 12;
+
    type RX_FINFO_Type is record
-      RXFLEN : Types.Bits_7   := 0;
-      RXFLE  : Types.Bits_3   := 0;
-      RXNSPL : Types.Bits_2   := 0;
-      RXBR   : Types.Bits_2   := 0;
-      RNG    : Types.Bits_1   := 0;
-      RXPRF  : Types.Bits_2   := 0;
-      RXPSR  : Types.Bits_2   := 0;
-      RXPACC : Types.Bits_12  := 0;
+      RXFLEN : RX_FINFO_RXFLEN_Field := 0;
+      RXFLE  : RX_FINFO_RXFLE_Field  := 0;
+      RXNSPL : RX_FINFO_RXNSPL_Field := 0;
+      RXBR   : RX_FINFO_RXBR_Field   := Data_Rate_110K;
+      RNG    : RX_FINFO_RNG_Field    := Disabled;
+      RXPRF  : RX_FINFO_RXPRFR_Field := Reserved_00;
+      RXPSR  : RX_FINFO_RXPSR_Field  := PLEN_16;
+      RXPACC : RX_FINFO_RXPACC_Field := 0;
 
       Reserved : Types.Bits_1 := 0;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1354,13 +1354,46 @@ is
    ----------------------------------------------------------------------------
    -- EXT_SYNC register file
 
-   -- EC_CTRL sub-register
+   ---------------------------
+   -- EC_CTRL sub-register  --
+   ---------------------------
+
+   type EC_CTRL_OSTSM_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  External transmit synchronisation mode enable.
+
+   type EC_CTRL_OSRSM_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  External receive synchronisation mode enable.
+
+   type EC_CTRL_PLLLDT_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Clock PLL lock detect tune.
+
+   type EC_CTRL_WAIT_Field is range 0 .. 255
+     with Size => 8;
+   --  Wait counter used for external transmit synchronisation and external
+   --  timebase reset.
+   --
+   --  The wait time is the number of external clock cycles (@ 38.4 MHz).
+
+   type EC_CTRL_OSTRM_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+
    type EC_CTRL_Type is record
-      OSTSM  : Types.Bits_1    := 0;
-      OSRSM  : Types.Bits_1    := 0;
-      PLLLDT : Types.Bits_1    := 0;
-      WAIT   : Types.Bits_8    := 0;
-      OSTRM  : Types.Bits_1    := 0;
+      OSTSM  : EC_CTRL_OSTSM_Field  := Disabled;
+      OSRSM  : EC_CTRL_OSRSM_Field  := Disabled;
+      PLLLDT : EC_CTRL_PLLLDT_Field := Enabled;
+      WAIT   : EC_CTRL_WAIT_Field   := 0;
+      OSTRM  : EC_CTRL_OSTRM_Field  := Disabled;
 
       Reserved : Types.Bits_20 := 0;
    end record
@@ -1378,9 +1411,16 @@ is
       Reserved at 0 range 12 .. 31;
    end record;
 
-   -- EC_RXTC sub-register
+   ---------------------------
+   -- EC_RXTC sub-register  --
+   ---------------------------
+
+   type EC_RCTC_RX_TS_EST_Field is range 0 .. 2**32 - 1
+     with Size => 32;
+   --  External clock synchronisation counter captured on RMARKER.
+
    type EC_RXTC_Type is record
-      RX_TS_EST : Types.Bits_32;
+      RX_TS_EST : EC_RCTC_RX_TS_EST_Field;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -1390,9 +1430,15 @@ is
       RX_TS_EST at 0 range 0 .. 31;
    end record;
 
-   -- EC_GOLP sub-register
+   ---------------------------
+   -- EC_GOLP sub-register  --
+   ---------------------------
+
+   type EC_GOLP_OFFSET_EXT_Field is range 0 .. 2**6 - 1
+     with Size => 6;
+
    type EC_GOLP_Type is record
-      OFFSET_EXT : Types.Bits_6  := 0;
+      OFFSET_EXT : EC_GOLP_OFFSET_EXT_Field := 0;
 
       Reserved   : Types.Bits_26 := 0;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2352,9 +2352,18 @@ is
    ----------------------------------------------------------------------------
    -- TX_CAL register file
 
-   -- TC_SARC sub-register
+   ---------------------------
+   -- TC_SARC sub-register  --
+   ---------------------------
+
+   type TC_SARC_SAR_CTRL_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Enable or disable the SAR
+
    type TC_SARC_Type is record
-      SAR_CTRL : Types.Bits_1 := 0;
+      SAR_CTRL : TC_SARC_SAR_CTRL_Field := Disabled;
 
       Reserved : Types.Bits_15 := 0;
    end record
@@ -2368,10 +2377,21 @@ is
       Reserved at 0 range 1 .. 15;
    end record;
 
-   -- TC_SARL sub-register
+   ---------------------------
+   -- TC_SARL sub-register  --
+   ---------------------------
+
+   type TC_SARL_SAR_LVBAT_Field is range 0 .. 255
+     with Size => 8;
+   --  Latest SAR reading for Voltage level.
+
+   type TC_SARL_SAR_LTEMP_Field is range 0 .. 255
+     with Size => 8;
+   --  Latest SAR reading for Temperature level.
+
    type TC_SARL_Type is record
-      SAR_LVBAT : Types.Bits_8 := 0;
-      SAR_LTEMP : Types.Bits_8 := 0;
+      SAR_LVBAT : TC_SARL_SAR_LVBAT_Field := 0;
+      SAR_LTEMP : TC_SARL_SAR_LTEMP_Field := 0;
 
       Reserved  : Types.Bits_8 := 0;
    end record
@@ -2386,10 +2406,21 @@ is
       Reserved  at 0 range 16 .. 23;
    end record;
 
-   -- TC_SARW sub-register
+   ---------------------------
+   -- TC_SARW sub-register  --
+   ---------------------------
+
+   type TC_SARW_WVBAT_Field is range 0 .. 255
+     with Size => 8;
+   --  SAR reading of Voltage level taken at last wakeup event.
+
+   type TC_SARW_WTEMP_Field is range 0 .. 255
+     with Size => 8;
+   --  SAR reading of temperature level taken at last wakeup event.
+
    type TC_SARW_Type is record
-      SAR_WVBAT : Types.Bits_8 := 0;
-      SAR_WTEMP : Types.Bits_8 := 0;
+      SAR_WVBAT : TC_SARW_WVBAT_Field := 0;
+      SAR_WTEMP : TC_SARW_WTEMP_Field := 0;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -2400,9 +2431,80 @@ is
       SAR_WTEMP at 0 range 8 .. 15;
    end record;
 
-   -- TC_PGDELAY sub-register
+   -------------------------------
+   --  TC_PG_CTRL sub-register  --
+   -------------------------------
+
+   type TC_PG_CTRL_PG_START_Field is
+     (No_Action,
+      Start)
+     with Size => 1;
+   --  Start the pulse generator calibration.
+
+   type TC_PG_CTRL_PG_TMEAS_Field is range 0 .. 15
+     with Size => 4;
+   --  Number of clock cycles over which to run the pulse generator cal counter.
+
+   type TC_PG_CTRL_Type is record
+      PG_START : TC_PG_CTRL_PG_START_Field := No_Action;
+      PG_TMEAS : TC_PG_CTRL_PG_TMEAS_Field := 0;
+
+      Reserved_1 : Bits_1;
+      Reserved_2 : Bits_2;
+   end record
+     with Size => 8,
+     Bit_Order => System.Low_Order_First,
+     Scalar_Storage_Order => System.Low_Order_First;
+
+   for TC_PG_CTRL_Type use record
+      PG_START   at 0 range 0 .. 0;
+
+      Reserved_1 at 0 range 1 .. 1;
+
+      PG_TMEAS   at 0 range 2 .. 5;
+
+      Reserved_2 at 0 range 6 .. 7;
+   end record;
+
+   ---------------------------------
+   --  TC_PG_STATUS sub-register  --
+   ---------------------------------
+
+   type TC_PG_STATUS_DELAY_CNT_Field is range 0 .. 2**12 - 1
+     with Size => 12;
+   --  Reference value required for temperature bandwidth compensation
+
+   type TC_PG_STATUS_Type is record
+      DELAY_CNT : TC_PG_STATUS_DELAY_CNT_Field := 0;
+
+      Reserved : Bits_4;
+   end record
+     with Size => 16,
+     Bit_Order => System.Low_Order_First,
+     Scalar_Storage_Order => System.Low_Order_First;
+
+   for TC_PG_STATUS_Type use record
+      DELAY_CNT at 0 range 0 .. 11;
+
+      Reserved  at 0 range 12 .. 15;
+   end record;
+
+   ------------------------------
+   -- TC_PGDELAY sub-register  --
+   ------------------------------
+
+   type TC_PGDELAY_Field is new Bits_8;
+   --  8-bit configuration register for setting the Pulse Generator Delay value.
+
+   TC_PGDELAY_Channel_1 : constant TC_PGDELAY_Field := 16#C9#;
+   TC_PGDELAY_Channel_2 : constant TC_PGDELAY_Field := 16#C2#;
+   TC_PGDELAY_Channel_3 : constant TC_PGDELAY_Field := 16#C5#;
+   TC_PGDELAY_Channel_4 : constant TC_PGDELAY_Field := 16#95#;
+   TC_PGDELAY_Channel_5 : constant TC_PGDELAY_Field := 16#B5#;
+   TC_PGDELAY_Channel_7 : constant TC_PGDELAY_Field := 16#93#;
+
    type TC_PGDELAY_Type is record
-      TC_PGDELAY : Types.Bits_8;
+      TC_PGDELAY : TC_PGDELAY_Field;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -2412,9 +2514,19 @@ is
       TC_PGDELAY at 0 range 0 .. 7;
    end record;
 
-   -- TC_PGTEST sub-register
+   -----------------------------
+   -- TC_PGTEST sub-register  --
+   -----------------------------
+
+   type TC_PGTEST_Field is new Bits_8;
+   --  8-bit configuration register for use in setting the transmitter into
+   --  continuous wave (CW) mode.
+
+   TC_PGTEST_Normal_Operation : constant TC_PGTEST_Field := 16#00#;
+   TC_PGTEST_Continuous_Wave  : constant TC_PGTEST_Field := 16#13#;
+
    type TC_PGTEST_Type is record
-      TC_PGTEST : Types.Bits_8;
+      TC_PGTEST : TC_PGTEST_Field := TC_PGTEST_Normal_Operation;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -3126,9 +3126,15 @@ is
    ----------------------------------------------------------------------------
    -- LDE_IF register file
 
-   -- LDE_THRESH sub-register
+   ------------------------------
+   -- LDE_THRESH sub-register  --
+   ------------------------------
+
+   type LDE_THRESH_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+
    type LDE_THRESH_Type is record
-      LDE_THRESH : Types.Bits_16;
+      LDE_THRESH : LDE_THRESH_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3138,10 +3144,21 @@ is
       LDE_THRESH at 0 range 0 .. 15;
    end record;
 
-   -- LDE_CFG1 sub-register
+   ----------------------------
+   -- LDE_CFG1 sub-register  --
+   ----------------------------
+
+   type LDE_CFG1_NTM_Field is range 0 .. 31
+     with Size => 5;
+   --  Noise Threshold Multiplier.
+
+   type LDE_CFG1_PMULT_Field is range 0 .. 7
+     with Size => 3;
+   --  Peak Multiplier.
+
    type LDE_CFG1_Type is record
-      NTM   : Types.Bits_5 := 2#0_1100#;
-      PMULT : Types.Bits_3 := 2#011#;
+      NTM   : LDE_CFG1_NTM_Field   := 12;
+      PMULT : LDE_CFG1_PMULT_Field := 3;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -3152,9 +3169,15 @@ is
       PMULT at 0 range 5 .. 7;
    end record;
 
-   -- LDE_PPINDX sub-register
+   ------------------------------
+   -- LDE_PPINDX sub-register  --
+   ------------------------------
+
+   type LDE_PPINDX_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+
    type LDE_PPINDX_Type is record
-      LDE_PPINDX : Types.Bits_16;
+      LDE_PPINDX : LDE_PPINDX_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3164,9 +3187,15 @@ is
       LDE_PPINDX at 0 range 0 .. 15;
    end record;
 
-   -- LDE_PPAMPL sub-register
+   ------------------------------
+   -- LDE_PPAMPL sub-register  --
+   ------------------------------
+
+   type LDE_PPAMLP_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+
    type LDE_PPAMPL_Type is record
-      LDE_PPAMPL : Types.Bits_16;
+      LDE_PPAMPL : LDE_PPAMLP_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3176,9 +3205,12 @@ is
       LDE_PPAMPL at 0 range 0 .. 15;
    end record;
 
-   -- LDE_RXANTD sub-register
+   ------------------------------
+   -- LDE_RXANTD sub-register  --
+   ------------------------------
+
    type LDE_RXANTD_Type is record
-      LDE_RXANTD : Types.Bits_16;
+      LDE_RXANTD : System_Time.Antenna_Delay_Time;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3188,9 +3220,17 @@ is
       LDE_RXANTD at 0 range 0 .. 15;
    end record;
 
-   -- LDE_CFG2 sub-register
+   ----------------------------
+   -- LDE_CFG2 sub-register  --
+   ----------------------------
+
+   type LDE_CFG2_Field is new Bits_16;
+
+   LDE_CFG2_16MHz : constant LDE_CFG2_Field := 16#1607#;
+   LDE_CFG2_64MHz : constant LDE_CFG2_Field := 16#0607#;
+
    type LDE_CFG2_Type is record
-      LDE_CFG2 : Types.Bits_16;
+      LDE_CFG2 : LDE_CFG2_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -3200,9 +3240,39 @@ is
       LDE_CFG2 at 0 range 0 .. 15;
    end record;
 
-   -- LDE_REPC sub-register
+   ----------------------------
+   -- LDE_REPC sub-register  --
+   ----------------------------
+
+   type LDE_REPC_Field is new Bits_16;
+
+   LDE_REPC_PCODE_1  : constant LDE_REPC_Field := 16#5998#;
+   LDE_REPC_PCODE_2  : constant LDE_REPC_Field := 16#5998#;
+   LDE_REPC_PCODE_3  : constant LDE_REPC_Field := 16#51EA#;
+   LDE_REPC_PCODE_4  : constant LDE_REPC_Field := 16#428E#;
+   LDE_REPC_PCODE_5  : constant LDE_REPC_Field := 16#451E#;
+   LDE_REPC_PCODE_6  : constant LDE_REPC_Field := 16#2E14#;
+   LDE_REPC_PCODE_7  : constant LDE_REPC_Field := 16#8000#;
+   LDE_REPC_PCODE_8  : constant LDE_REPC_Field := 16#51EA#;
+   LDE_REPC_PCODE_9  : constant LDE_REPC_Field := 16#28F4#;
+   LDE_REPC_PCODE_10 : constant LDE_REPC_Field := 16#3332#;
+   LDE_REPC_PCODE_11 : constant LDE_REPC_Field := 16#3AE0#;
+   LDE_REPC_PCODE_12 : constant LDE_REPC_Field := 16#3D70#;
+   LDE_REPC_PCODE_13 : constant LDE_REPC_Field := 16#3AE0#;
+   LDE_REPC_PCODE_14 : constant LDE_REPC_Field := 16#35C2#;
+   LDE_REPC_PCODE_15 : constant LDE_REPC_Field := 16#2B84#;
+   LDE_REPC_PCODE_16 : constant LDE_REPC_Field := 16#35C2#;
+   LDE_REPC_PCODE_17 : constant LDE_REPC_Field := 16#3332#;
+   LDE_REPC_PCODE_18 : constant LDE_REPC_Field := 16#35C2#;
+   LDE_REPC_PCODE_19 : constant LDE_REPC_Field := 16#35C2#;
+   LDE_REPC_PCODE_20 : constant LDE_REPC_Field := 16#47AE#;
+   LDE_REPC_PCODE_21 : constant LDE_REPC_Field := 16#3AE0#;
+   LDE_REPC_PCODE_22 : constant LDE_REPC_Field := 16#3850#;
+   LDE_REPC_PCODE_23 : constant LDE_REPC_Field := 16#30A2#;
+   LDE_REPC_PCODE_24 : constant LDE_REPC_Field := 16#3850#;
+
    type LDE_REPC_Type is record
-      LDE_REPC : Types.Bits_16;
+      LDE_REPC : LDE_REPC_Field;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -304,17 +304,67 @@ is
    ----------------------------------------------------------------------------
    -- TX_FCTRL register file
 
+   type TX_FCTRL_TFLEN_Field is range 0 .. 127
+     with Size => 7;
+   --  Transmit Frame Length.
+
+   type TX_FCTRL_TFLE_Field is range 0 .. 7
+     with Size => 3;
+   --  Transmit Frame Length Extension.
+
+   type TX_FCTRL_TXBR_Field is
+     (Data_Rate_110K,
+      Data_Rate_850K,
+      Data_Rate_6M8,
+      Reserved)
+     with Size => 2;
+   --  Transmit Bit Rate.
+
+   type TX_FCTRL_TR_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Transmit Ranging enable.
+
+   type TX_FCTRL_TXPRF_Field is
+     (PRF_4MHz,
+      PRF_16MHz,
+      PRF_64MHz,
+      Reserved)
+     with Size => 2;
+   --  Transmit Pulse Repetition Frequency.
+
+   type TX_FCTRL_TXPSR_Field is
+     (PLEN_16,
+      PLEN_64,
+      PLEN_1024,
+      PLEN_4096)
+     with Size => 2;
+   --  Transmit Preamble Symbol Repetitions (PSR).
+
+   type TX_FCTRL_PE_Field is range 0 .. 3
+     with Size => 2;
+   --  Preamble Extension.
+
+   type TX_FCTRL_TXBOFFS_Field is range 0 .. 2**10 - 1
+     with Size => 10;
+   --  Transmit buffer index offset.
+
+   type TX_FCTRL_IFSDELAY_Field is range 0 .. 255
+     with Size => 8;
+   --  Inter-Frame Spacing.
+
    type TX_FCTRL_Type is record
-      TFLEN    : Types.Bits_7  := 12;
-      TFLE     : Types.Bits_3  := 0;
-      R        : Types.Bits_3  := 0;
-      TXBR     : Types.Bits_2  := 0;
-      TR       : Types.Bits_1  := 0;
-      TXPRF    : Types.Bits_2  := 0;
-      TXPSR    : Types.Bits_2  := 0;
-      PE       : Types.Bits_2  := 0;
-      TXBOFFS  : Types.Bits_10 := 0;
-      IFSDELAY : Types.Bits_8  := 0;
+      TFLEN    : TX_FCTRL_TFLEN_Field    := 12;
+      TFLE     : TX_FCTRL_TFLE_Field     := 0;
+      R        : Types.Bits_3            := 0;
+      TXBR     : TX_FCTRL_TXBR_Field     := Data_Rate_6M8;
+      TR       : TX_FCTRL_TR_Field       := Disabled;
+      TXPRF    : TX_FCTRL_TXPRF_Field    := PRF_16MHz;
+      TXPSR    : TX_FCTRL_TXPSR_Field    := PLEN_64;
+      PE       : TX_FCTRL_PE_Field       := 0;
+      TXBOFFS  : TX_FCTRL_TXBOFFS_Field  := 0;
+      IFSDELAY : TX_FCTRL_IFSDELAY_Field := 0;
    end record
      with Size => 40,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -839,10 +839,28 @@ is
    ----------------------------------------------------------------------------
    -- RX_TTCKO register file
 
+   type RX_TTCKO_RXTOFS_Field is range -2**18 .. 2**18 - 1
+     with Size => 19;
+   --  RX time tracking offset.
+
+   type RX_TTCKO_RSMPDEL_Field is range 0 .. 255
+     with Size => 8;
+   --  This 8-bit field reports an internal re-sampler delay value.
+
+   type RX_TTCKO_RCPHASE_Field is
+   delta 360.0 / 127.0
+   range 0.0 .. 360.0
+     with Small => 360.0 / 127.0,
+       Size => 7;
+   --  This 7-bit field reports the receive carrier phase adjustment at time
+   --  the ranging timestamp is made. This gives the phase (7 bits = 360 degrees)
+   --  of the internal carrier tracking loop at the time that the RX timestamp
+   --  is received.
+
    type RX_TTCKO_Type is record
-      RXTOFS  : Types.Bits_19   := 0;
-      RSMPDEL : Types.Bits_8    := 0;
-      RCPHASE : Types.Bits_7    := 0;
+      RXTOFS  : RX_TTCKO_RXTOFS_Field  := 0;
+      RSMPDEL : RX_TTCKO_RSMPDEL_Field := 0;
+      RCPHASE : RX_TTCKO_RCPHASE_Field := RX_TTCKO_RCPHASE_Field'First;
 
       Reserved_1 : Types.Bits_5 := 0;
       Reserved_2 : Types.Bits_1 := 0;
@@ -857,9 +875,9 @@ is
       Reserved_1 at 0 range 19 .. 23;
 
       RSMPDEL    at 0 range 24 .. 31;
-      RCPHASE    at 4 range  0 ..  6;
+      RCPHASE    at 0 range 32 .. 38;
 
-      Reserved_2 at 4 range  7 ..  7;
+      Reserved_2 at 0 range 39 .. 39;
    end record;
 
    ----------------------------------------------------------------------------

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -883,11 +883,19 @@ is
    ----------------------------------------------------------------------------
    -- RX_TIME register file
 
+   type RX_TIME_FP_INDEX_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  First path index.
+
+   type RX_TIME_FP_AMPL1_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  First Path Amplitude point 1.
+
    type RX_TIME_Type is record
-      RX_STAMP : Types.Bits_40 := 0;
-      FP_INDEX : Types.Bits_16 := 0;
-      FP_AMPL1 : Types.Bits_16 := 0;
-      RX_RAWST : Types.Bits_40 := 0;
+      RX_STAMP : System_Time.Fine_System_Time   := 0.0;
+      FP_INDEX : RX_TIME_FP_INDEX_Field         := 0;
+      FP_AMPL1 : RX_TIME_FP_AMPL1_Field         := 0;
+      RX_RAWST : System_Time.Coarse_System_Time := 0.0;
    end record
      with Size => 8*14,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1471,10 +1471,10 @@ is
       Imag at 2 range 0 .. 15;
    end record;
 
-   type ACC_MEM_CIR_Array is array(0 .. 1015) of ACC_MEM_Sample_Type;
+   type ACC_MEM_CIR_Array is array(Types.Index range <>) of ACC_MEM_Sample_Type;
 
    type ACC_MEM_Type is record
-      CIR : ACC_MEM_CIR_Array;
+      CIR : ACC_MEM_CIR_Array (0 .. 1015);
    end record
      with Size => 4064*8,
      Bit_Order => System.Low_Order_First,
@@ -1487,17 +1487,92 @@ is
    ----------------------------------------------------------------------------
    -- GPIO_CTRL register file
 
-   -- GPIO_MODE sub-register
+   -----------------------------
+   -- GPIO_MODE sub-register  --
+   -----------------------------
+
+   type GPIO_MODE_MSGP0_Field is
+     (GPIO0,
+      RXOKLED,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO0/RXOKLED.
+
+   type GPIO_MODE_MSGP1_Field is
+     (GPIO1,
+      SFDLED,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO1/SFDLED.
+
+   type GPIO_MODE_MSGP2_Field is
+     (GPIO2,
+      RXLED,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO2/RXLED
+
+   type GPIO_MODE_MSGP3_Field is
+     (GPIO3,
+      TXLED,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO3/TXLED
+
+   type GPIO_MODE_MSGP4_Field is
+     (GPIO4,
+      EXTPA,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO4/EXTPA
+
+   type GPIO_MODE_MSGP5_Field is
+     (GPIO5,
+      EXTTXE,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO5/EXTTXE
+
+   type GPIO_MODE_MSGP6_Field is
+     (GPIO6,
+      EXTRXE,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for GPIO6/EXTRXE
+
+   type GPIO_MODE_MSGP7_Field is
+     (SYNC,
+      GPIO7,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for SYNC/GPIO7
+
+   type GPIO_MODE_MSGP8_Field is
+     (IRQ,
+      GPIO8,
+      Reserved_10,
+      Reserved_11)
+     with Size => 2;
+   --  Mode Selection for IRQ/GPIO8
+
    type GPIO_MODE_Type is record
-      MSGP0 : Types.Bits_2      := 0;
-      MSGP1 : Types.Bits_2      := 0;
-      MSGP2 : Types.Bits_2      := 0;
-      MSGP3 : Types.Bits_2      := 0;
-      MSGP4 : Types.Bits_2      := 0;
-      MSGP5 : Types.Bits_2      := 0;
-      MSGP6 : Types.Bits_2      := 0;
-      MSGP7 : Types.Bits_2      := 0;
-      MSGP8 : Types.Bits_2      := 0;
+      MSGP0 : GPIO_MODE_MSGP0_Field := GPIO0;
+      MSGP1 : GPIO_MODE_MSGP1_Field := GPIO1;
+      MSGP2 : GPIO_MODE_MSGP2_Field := GPIO2;
+      MSGP3 : GPIO_MODE_MSGP3_Field := GPIO3;
+      MSGP4 : GPIO_MODE_MSGP4_Field := GPIO4;
+      MSGP5 : GPIO_MODE_MSGP5_Field := GPIO5;
+      MSGP6 : GPIO_MODE_MSGP6_Field := GPIO6;
+      MSGP7 : GPIO_MODE_MSGP7_Field := SYNC;
+      MSGP8 : GPIO_MODE_MSGP8_Field := IRQ;
 
       Reserved_1 : Types.Bits_6 := 0;
       Reserved_2 : Types.Bits_8 := 0;
@@ -1522,26 +1597,45 @@ is
       Reserved_2 at 0 range 24 .. 31;
    end record;
 
-   -- GPIO_DIR sub-register
+   ----------------------------
+   -- GPIO_DIR sub-register  --
+   ----------------------------
+
+   type GPIO_DIR_GDP_Field is
+     (Output,
+      Input)
+     with Size => 1;
+   --  Direction Selection for GPIOx
+
+   type GPIO_DIR_GDM_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  Mask for setting the direction of GPIOx.
+   --
+   --  When writing to GDP0 so select the I/O direction of GPIOx, the value of
+   --  GDPx is only changed if this GDMx mask bit is Set for the write
+   --  operation. GDMx will always read as 0.
+
    type GPIO_DIR_Type is record
-      GDP0 : Types.Bits_1 := 1;
-      GDP1 : Types.Bits_1 := 1;
-      GDP2 : Types.Bits_1 := 1;
-      GDP3 : Types.Bits_1 := 1;
-      GDM0 : Types.Bits_1 := 0;
-      GDM1 : Types.Bits_1 := 0;
-      GDM2 : Types.Bits_1 := 0;
-      GDM3 : Types.Bits_1 := 0;
-      GDP4 : Types.Bits_1 := 1;
-      GDP5 : Types.Bits_1 := 1;
-      GDP6 : Types.Bits_1 := 1;
-      GDP7 : Types.Bits_1 := 1;
-      GDM4 : Types.Bits_1 := 0;
-      GDM5 : Types.Bits_1 := 0;
-      GDM6 : Types.Bits_1 := 0;
-      GDM7 : Types.Bits_1 := 0;
-      GDP8 : Types.Bits_1 := 1;
-      GDM8 : Types.Bits_1 := 0;
+      GDP0 : GPIO_DIR_GDP_Field := Input;
+      GDP1 : GPIO_DIR_GDP_Field := Input;
+      GDP2 : GPIO_DIR_GDP_Field := Input;
+      GDP3 : GPIO_DIR_GDP_Field := Input;
+      GDM0 : GPIO_DIR_GDM_Field := Clear;
+      GDM1 : GPIO_DIR_GDM_Field := Clear;
+      GDM2 : GPIO_DIR_GDM_Field := Clear;
+      GDM3 : GPIO_DIR_GDM_Field := Clear;
+      GDP4 : GPIO_DIR_GDP_Field := Input;
+      GDP5 : GPIO_DIR_GDP_Field := Input;
+      GDP6 : GPIO_DIR_GDP_Field := Input;
+      GDP7 : GPIO_DIR_GDP_Field := Input;
+      GDM4 : GPIO_DIR_GDM_Field := Clear;
+      GDM5 : GPIO_DIR_GDM_Field := Clear;
+      GDM6 : GPIO_DIR_GDM_Field := Clear;
+      GDM7 : GPIO_DIR_GDM_Field := Clear;
+      GDP8 : GPIO_DIR_GDP_Field := Input;
+      GDM8 : GPIO_DIR_GDM_Field := Clear;
 
       Reserved_1 : Types.Bits_3  := 0;
       Reserved_2 : Types.Bits_11 := 0;
@@ -1576,26 +1670,34 @@ is
       Reserved_2 at 0 range 21 .. 31;
    end record;
 
-   -- GPIO_DOUT sub-register
+   -----------------------------
+   -- GPIO_DOUT sub-register  --
+   -----------------------------
+
+   type GPIO_DOUT_GOM_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+
    type GPIO_DOUT_Type is record
-      GOP0 : Types.Bits_1 := 0;
-      GOP1 : Types.Bits_1 := 0;
-      GOP2 : Types.Bits_1 := 0;
-      GOP3 : Types.Bits_1 := 0;
-      GOM0 : Types.Bits_1 := 0;
-      GOM1 : Types.Bits_1 := 0;
-      GOM2 : Types.Bits_1 := 0;
-      GOM3 : Types.Bits_1 := 0;
-      GOP4 : Types.Bits_1 := 0;
-      GOP5 : Types.Bits_1 := 0;
-      GOP6 : Types.Bits_1 := 0;
-      GOP7 : Types.Bits_1 := 0;
-      GOM4 : Types.Bits_1 := 0;
-      GOM5 : Types.Bits_1 := 0;
-      GOM6 : Types.Bits_1 := 0;
-      GOM7 : Types.Bits_1 := 0;
-      GOP8 : Types.Bits_1 := 0;
-      GOM8 : Types.Bits_1 := 0;
+      GOP0 : Types.Bits_1        := 0;
+      GOP1 : Types.Bits_1        := 0;
+      GOP2 : Types.Bits_1        := 0;
+      GOP3 : Types.Bits_1        := 0;
+      GOM0 : GPIO_DOUT_GOM_Field := Clear;
+      GOM1 : GPIO_DOUT_GOM_Field := Clear;
+      GOM2 : GPIO_DOUT_GOM_Field := Clear;
+      GOM3 : GPIO_DOUT_GOM_Field := Clear;
+      GOP4 : Types.Bits_1        := 0;
+      GOP5 : Types.Bits_1        := 0;
+      GOP6 : Types.Bits_1        := 0;
+      GOP7 : Types.Bits_1        := 0;
+      GOM4 : GPIO_DOUT_GOM_Field := Clear;
+      GOM5 : GPIO_DOUT_GOM_Field := Clear;
+      GOM6 : GPIO_DOUT_GOM_Field := Clear;
+      GOM7 : GPIO_DOUT_GOM_Field := Clear;
+      GOP8 : Types.Bits_1        := 0;
+      GOM8 : GPIO_DOUT_GOM_Field := Clear;
 
       Reserved_1 : Types.Bits_3  := 0;
       Reserved_2 : Types.Bits_11 := 0;
@@ -1630,17 +1732,26 @@ is
       Reserved_2 at 0 range 21 .. 31;
    end record;
 
-   -- GPIO_IRQE sub-register
+   -----------------------------
+   -- GPIO_IRQE sub-register  --
+   -----------------------------
+
+   type GPIO_IREQ_GIRQE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO IRQ Enable for GPIOx input.
+
    type GPIO_IRQE_Type is record
-      GIRQE0 : Types.Bits_1 := 0;
-      GIRQE1 : Types.Bits_1 := 0;
-      GIRQE2 : Types.Bits_1 := 0;
-      GIRQE3 : Types.Bits_1 := 0;
-      GIRQE4 : Types.Bits_1 := 0;
-      GIRQE5 : Types.Bits_1 := 0;
-      GIRQE6 : Types.Bits_1 := 0;
-      GIRQE7 : Types.Bits_1 := 0;
-      GIRQE8 : Types.Bits_1 := 0;
+      GIRQE0 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE1 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE2 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE3 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE4 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE5 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE6 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE7 : GPIO_IREQ_GIRQE_Field := Disabled;
+      GIRQE8 : GPIO_IREQ_GIRQE_Field := Disabled;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1662,17 +1773,26 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_ISEN sub-register
+   -----------------------------
+   -- GPIO_ISEN sub-register  --
+   -----------------------------
+
+   type GPIO_ISEN_GISEN_Field is
+     (Active_High,
+      Active_Low)
+     with Size => 1;
+   --  GPIO IRQ Sense selection GPIO0 input.
+
    type GPIO_ISEN_Type is record
-      GISEN0 : Types.Bits_1 := 0;
-      GISEN1 : Types.Bits_1 := 0;
-      GISEN2 : Types.Bits_1 := 0;
-      GISEN3 : Types.Bits_1 := 0;
-      GISEN4 : Types.Bits_1 := 0;
-      GISEN5 : Types.Bits_1 := 0;
-      GISEN6 : Types.Bits_1 := 0;
-      GISEN7 : Types.Bits_1 := 0;
-      GISEN8 : Types.Bits_1 := 0;
+      GISEN0 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN1 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN2 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN3 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN4 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN5 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN6 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN7 : GPIO_ISEN_GISEN_Field := Active_High;
+      GISEN8 : GPIO_ISEN_GISEN_Field := Active_High;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1694,17 +1814,26 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_IMODE sub-register
+   ------------------------------
+   -- GPIO_IMODE sub-register  --
+   ------------------------------
+
+   type GPIO_IMODE_GIMOD_Field is
+     (Level,
+      Edge)
+     with Size => 1;
+   --  GPIO IRQ Mode selection for GPIOx input.
+
    type GPIO_IMODE_Type is record
-      GIMOD0 : Types.Bits_1 := 0;
-      GIMOD1 : Types.Bits_1 := 0;
-      GIMOD2 : Types.Bits_1 := 0;
-      GIMOD3 : Types.Bits_1 := 0;
-      GIMOD4 : Types.Bits_1 := 0;
-      GIMOD5 : Types.Bits_1 := 0;
-      GIMOD6 : Types.Bits_1 := 0;
-      GIMOD7 : Types.Bits_1 := 0;
-      GIMOD8 : Types.Bits_1 := 0;
+      GIMOD0 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD1 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD2 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD3 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD4 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD5 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD6 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD7 : GPIO_IMODE_GIMOD_Field := Level;
+      GIMOD8 : GPIO_IMODE_GIMOD_Field := Level;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1726,17 +1855,26 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_IBES sub-register
+   -----------------------------
+   -- GPIO_IBES sub-register  --
+   -----------------------------
+
+   type GPIO_IBES_GIBES_Field is
+     (Use_GPIO_IMODE,
+      Both_Edges)
+     with Size => 1;
+   --  GPIO IRQ "Both Edge" selection for GPIOx input.
+
    type GPIO_IBES_Type is record
-      GIBES0 : Types.Bits_1 := 0;
-      GIBES1 : Types.Bits_1 := 0;
-      GIBES2 : Types.Bits_1 := 0;
-      GIBES3 : Types.Bits_1 := 0;
-      GIBES4 : Types.Bits_1 := 0;
-      GIBES5 : Types.Bits_1 := 0;
-      GIBES6 : Types.Bits_1 := 0;
-      GIBES7 : Types.Bits_1 := 0;
-      GIBES8 : Types.Bits_1 := 0;
+      GIBES0 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES1 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES2 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES3 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES4 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES5 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES6 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES7 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
+      GIBES8 : GPIO_IBES_GIBES_Field := Use_GPIO_IMODE;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1758,17 +1896,26 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_ICLR sub-register
+   -----------------------------
+   -- GPIO_ICLR sub-register  --
+   -----------------------------
+
+   type GPIO_ICLR_GICLR_Field is
+     (No_Action,
+      Clear_IRQ_Latch)
+     with Size => 1;
+   --  GPIO IRQ latch clear for GPIOx input.
+
    type GPIO_ICLR_Type is record
-      GICLR0 : Types.Bits_1 := 0;
-      GICLR1 : Types.Bits_1 := 0;
-      GICLR2 : Types.Bits_1 := 0;
-      GICLR3 : Types.Bits_1 := 0;
-      GICLR4 : Types.Bits_1 := 0;
-      GICLR5 : Types.Bits_1 := 0;
-      GICLR6 : Types.Bits_1 := 0;
-      GICLR7 : Types.Bits_1 := 0;
-      GICLR8 : Types.Bits_1 := 0;
+      GICLR0 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR1 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR2 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR3 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR4 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR5 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR6 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR7 : GPIO_ICLR_GICLR_Field := No_Action;
+      GICLR8 : GPIO_ICLR_GICLR_Field := No_Action;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1790,17 +1937,26 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_IDBE sub-register
+   -----------------------------
+   -- GPIO_IDBE sub-register  --
+   -----------------------------
+
+   type GPIO_IDBE_GIDBE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  GPIO IRQ de-bounce enable for GPIOx.
+
    type GPIO_IDBE_Type is record
-      GIDBE0 : Types.Bits_1 := 0;
-      GIDBE1 : Types.Bits_1 := 0;
-      GIDBE2 : Types.Bits_1 := 0;
-      GIDBE3 : Types.Bits_1 := 0;
-      GIDBE4 : Types.Bits_1 := 0;
-      GIDBE5 : Types.Bits_1 := 0;
-      GIDBE6 : Types.Bits_1 := 0;
-      GIDBE7 : Types.Bits_1 := 0;
-      GIDBE8 : Types.Bits_1 := 0;
+      GIDBE0 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE1 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE2 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE3 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE4 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE5 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE6 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE7 : GPIO_IDBE_GIDBE_Field := Disabled;
+      GIDBE8 : GPIO_IDBE_GIDBE_Field := Disabled;
 
       Reserved : Types.Bits_23 := 0;
    end record
@@ -1822,7 +1978,10 @@ is
       Reserved at 0 range  9 .. 31;
    end record;
 
-   -- GPIO_RAW sub-register
+   ----------------------------
+   -- GPIO_RAW sub-register  --
+   ----------------------------
+
    type GPIO_RAW_Type is record
       GRAWP0 : Types.Bits_1 := 0;
       GRAWP1 : Types.Bits_1 := 0;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1099,11 +1099,46 @@ is
    ----------------------------------------------------------------------------
    -- TX_POWER register file
 
+   type TX_POWER_COARSE_Field is
+     (Gain_15_dB,
+      Gain_12_5_dB,
+      Gain_10_dB,
+      Gain_7_5_dB,
+      Gain_5_dB,
+      Gain_2_5_dB,
+      Gain_0_dB,
+      Off) --  No output when used
+     with Size => 3;
+   --  Coarse (DA setting) gain in 2.5 dB steps.
+   --
+   --  Unfortunately we can't use a fixed-point type here (like the fine gain)
+   --  due to the reversed HW representation of the coarse gain and the
+   --  need for the special "Off" setting.
+
+   type TX_POWER_FINE_Field is delta 0.5 range 0.0 .. 15.5
+     with Size => 5;
+   --  Fine (Mixer) gain in dB (Decibels) in 0.5 dB steps.
+
+   type TX_POWER_Field is record
+      Fine_Gain   : TX_POWER_FINE_Field   := 0.0;
+      Coarse_Gain : TX_POWER_COARSE_Field := Gain_15_dB;
+   end record
+     with Size => 8;
+
+   for TX_POWER_Field use record
+      Fine_Gain   at 0 range 0 .. 4;
+      Coarse_Gain at 0 range 5 .. 7;
+   end record;
+
    type TX_POWER_Type is record
-      BOOSTNORM : Types.Bits_8 := 16#22#;
-      BOOSTP500 : Types.Bits_8 := 16#02#;
-      BOOSTP250 : Types.Bits_8 := 16#08#;
-      BOOSTP125 : Types.Bits_8 := 16#0E#;
+      BOOSTNORM : TX_POWER_Field := (Fine_Gain   => 1.0,
+                                     Coarse_Gain => Gain_12_5_dB);
+      BOOSTP500 : TX_POWER_Field := (Fine_Gain   => 1.0,
+                                     Coarse_Gain => Gain_15_dB);
+      BOOSTP250 : TX_POWER_Field := (Fine_Gain   => 4.0,
+                                     Coarse_Gain => Gain_15_dB);
+      BOOSTP125 : TX_POWER_Field := (Fine_Gain   => 7.0,
+                                     Coarse_Gain => Gain_15_dB);
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2911,7 +2911,10 @@ is
    ----------------------------------------------------------------------------
    -- OTP_IF register file
 
-   -- OTP_WDAT sub-register
+   ----------------------------
+   -- OTP_WDAT sub-register  --
+   ----------------------------
+
    type OTP_WDAT_Type is record
       OTP_WDAT : Types.Bits_32;
    end record
@@ -2923,9 +2926,14 @@ is
       OTP_WDAT at 0 range 0 .. 31;
    end record;
 
-   -- OTP_ADDR sub-register
+   ----------------------------
+   -- OTP_ADDR sub-register  --
+   ----------------------------
+
+   type OTP_ADDR_Field is new Bits_11;
+
    type OTP_ADDR_Type is record
-      OTP_ADDR : Types.Bits_11 := 0;
+      OTP_ADDR : OTP_ADDR_Field;
 
       Reserved : Types.Bits_5  := 0;
    end record
@@ -2939,14 +2947,55 @@ is
       Reserved at 0 range 11 .. 15;
    end record;
 
-   -- OTP_CTRL sub-register
+   ----------------------------
+   -- OTP_CTRL sub-register  --
+   ----------------------------
+
+   type OTP_CTRL_OPTRDEN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit forces the OTP into manual read mode.
+
+   type OTP_CTRL_OTPREAD_Field is
+     (No_Action,
+      Trigger_Read)
+     with Size => 1;
+   --  This bit commands a read operation from the address specified in the
+   --  OTP_ADDR register, the value read will then be available in the OTP_RDAT
+   --  register.
+
+   type OTP_CTRL_OTPMRWR_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  OTP mode register write.
+
+   type OTP_CTRL_PPROG_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  Setting this bit will cause the contents of OTP_WDAT to be written to
+   --  OTP_ADDR.
+
+   type OTP_CTRL_OTPMR_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+
+   type OTP_CTRL_LDELOAD_Field is
+     (No_Action,
+      Load_LDE_Microcode)
+     with Size => 1;
+   --  This bit forces a load of LDE microcode.
+
    type OTP_CTRL_Type is record
-      OTPRDEN : Types.Bits_1 := 0;
-      OTPREAD : Types.Bits_1 := 0;
-      OTPMRWR : Types.Bits_1 := 0;
-      OTPPROG : Types.Bits_1 := 0;
-      OTPMR   : Types.Bits_4 := 0;
-      LDELOAD : Types.Bits_1 := 0;
+      OTPRDEN : OTP_CTRL_OPTRDEN_Field := Disabled;
+      OTPREAD : OTP_CTRL_OTPREAD_Field := No_Action;
+      OTPMRWR : OTP_CTRL_OTPMRWR_Field := Clear;
+      OTPPROG : OTP_CTRL_PPROG_Field   := Clear;
+      OTPMR   : OTP_CTRL_OTPMR_Field   := Clear;
+      LDELOAD : OTP_CTRL_LDELOAD_Field := No_Action;
 
       Reserved_1 : Types.Bits_1 := 0;
       Reserved_2 : Types.Bits_2 := 0;
@@ -2974,7 +3023,10 @@ is
       LDELOAD    at 0 range 15 .. 15;
    end record;
 
-   -- OTP_STAT sub-register
+   ----------------------------
+   -- OTP_STAT sub-register  --
+   ----------------------------
+
    type OTP_STAT_Type is record
       OTPPRGD  : Types.Bits_1 := 0;
       OTPVPOK  : Types.Bits_1 := 0;
@@ -2992,7 +3044,10 @@ is
       Reserved at 0 range 2 .. 15;
    end record;
 
-   -- OTP_RDAT sub-register
+   ----------------------------
+   -- OTP_RDAT sub-register  --
+   ----------------------------
+
    type OTP_RDAT_Type is record
       OTP_RDAT : Types.Bits_32;
    end record
@@ -3004,7 +3059,10 @@ is
       OTP_RDAT at 0 range 0 .. 31;
    end record;
 
-   -- OTP_SRDAT sub-register
+   -----------------------------
+   -- OTP_SRDAT sub-register  --
+   -----------------------------
+
    type OTP_SRDAT_Type is record
       OTP_SRDAT : Types.Bits_32;
    end record
@@ -3016,14 +3074,39 @@ is
       OTP_SRDAT at 0 range 0 .. 31;
    end record;
 
-   -- OTP_SF sub-register
+   --------------------------
+   -- OTP_SF sub-register  --
+   --------------------------
+
+   type OTP_SF_OPS_KICK_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  This bit when set initiates a load of the operating parameter set
+   --  selected by the OPS_SEL configuration below.
+
+   type OTP_SF_LDO_KICK_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  This bit when set initiates the loading of the LDOTUNE_CAL parameter
+   --  from OTP address 0x4 into the LDOTUNE register
+
+   type OTP_SF_OPS_SEL_Field is
+     (Length64,
+      Tight,
+      Default,
+      Reserved)
+     with Size => 2;
+   --  Operating parameter set selection.
+
    type OTP_SF_Type is record
-      OPS_KICK : Types.Bits_1 := 0;
-      LDO_KICK : Types.Bits_1 := 0;
-      OPS_SEL  : Types.Bits_1 := 0;
+      OPS_KICK : OTP_SF_OPS_KICK_Field := Clear;
+      LDO_KICK : OTP_SF_LDO_KICK_Field := Clear;
+      OPS_SEL  : OTP_SF_OPS_SEL_Field  := Length64;
 
       Reserved_1 : Types.Bits_3 := 0;
-      Reserved_2 : Types.Bits_2 := 0;
+      Reserved_2 : Types.Bits_1 := 0;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -3035,9 +3118,9 @@ is
 
       Reserved_1 at 0 range 2 .. 4;
 
-      OPS_SEL    at 0 range 5 .. 5;
+      OPS_SEL    at 0 range 5 .. 6;
 
-      Reserved_2 at 0 range 6 .. 7;
+      Reserved_2 at 0 range 7 .. 7;
    end record;
 
    ----------------------------------------------------------------------------

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2613,16 +2613,68 @@ is
    ----------------------------------------------------------------------------
    -- AON register file
 
-   -- AON_WCFG sub-register
+   ----------------------------
+   -- AON_WCFG sub-register  --
+   ----------------------------
+
+   type AON_WCFG_ONW_RADC_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up Run the (temperature and voltage) Analog-to-Digital Convertors.
+
+   type AON_WCFG_ONW_RX_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up turn on the Receiver.
+
+   type AON_WCFG_ONW_LEUI_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up load the EUI from OTP memory into the EUI register.
+
+   type AON_WCFG_ONW_LDC_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-upload configurations from the AON memory into the host
+   --  interface register set.
+
+   type AON_WCFG_ONW_L64_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up load the Length64 receiver operating parameter set.
+
+   type AON_WCFG_PRES_SLEEP_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Preserve Sleep.
+
+   type AON_WCFG_ONW_LLDE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up load the LDE microcode.
+
+   type AON_WCFG_ONW_LLD0_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  On Wake-up load the LDOTUNE value from OTP.
+
    type AON_WCFG_Type is record
-      ONW_RAD    : Types.Bits_1 := 0;
-      ONW_RX     : Types.Bits_1 := 0;
-      ONW_LEUI   : Types.Bits_1 := 0;
-      ONW_LDC    : Types.Bits_1 := 0;
-      ONW_L64    : Types.Bits_1 := 0;
-      PRES_SLEE  : Types.Bits_1 := 0;
-      ONW_LLDE   : Types.Bits_1 := 0;
-      ONW_LLD    : Types.Bits_1 := 0;
+      ONW_RADC   : AON_WCFG_ONW_RADC_Field   := Disabled;
+      ONW_RX     : AON_WCFG_ONW_RX_Field     := Disabled;
+      ONW_LEUI   : AON_WCFG_ONW_LEUI_Field   := Disabled;
+      ONW_LDC    : AON_WCFG_ONW_LDC_Field    := Disabled;
+      ONW_L64    : AON_WCFG_ONW_L64_Field    := Disabled;
+      PRES_SLEEP : AON_WCFG_PRES_SLEEP_Field := Disabled;
+      ONW_LLDE   : AON_WCFG_ONW_LLDE_Field   := Disabled;
+      ONW_LLD0   : AON_WCFG_ONW_LLD0_Field   := Disabled;
 
       Reserved_1 : Types.Bits_1 := 0;
       Reserved_2 : Types.Bits_2 := 0;
@@ -2634,7 +2686,7 @@ is
      Scalar_Storage_Order => System.Low_Order_First;
 
    for AON_WCFG_Type use record
-      ONW_RAD    at 0 range  0 ..  0;
+      ONW_RADC   at 0 range  0 ..  0;
       ONW_RX     at 0 range  1 ..  1;
 
       Reserved_1 at 0 range  2 .. 2;
@@ -2645,23 +2697,58 @@ is
 
       ONW_LDC    at 0 range  6 ..  6;
       ONW_L64    at 0 range  7 ..  7;
-      PRES_SLEE  at 0 range  8 ..  8;
+      PRES_SLEEP at 0 range  8 ..  8;
 
       Reserved_3 at 0 range  9 .. 10;
 
       ONW_LLDE   at 0 range 11 .. 11;
-      ONW_LLD    at 0 range 12 .. 12;
+      ONW_LLD0   at 0 range 12 .. 12;
 
       Reserved_4 at 0 range 13 .. 15;
    end record;
 
-   -- AON_CTRL sub-register
+   ----------------------------
+   -- AON_CTRL sub-register  --
+   ----------------------------
+
+   type AON_CTRL_RESTORE_Field is
+     (No_Action,
+      Restore)
+     with Size => 1;
+   --  When this bit is set the DW1000 will copy the user configurations from
+   --  the AON memory to the host interface register set.
+
+   type AON_CTRL_SAVE_Field is
+     (No_Action,
+      Save)
+     with Size => 1;
+   --  When this bit is set the DW1000 will copy the user configurations from
+   --  the host interface register set into the AON memory.
+
+   type AON_CTRL_UPL_CFG_Field is
+     (No_Action,
+      Upload)
+     with Size => 1;
+   --  Upload the AON block configurations to the AON.
+
+   type AON_CTRL_DCA_READ_Field is
+     (No_Action,
+      Trigger_Read)
+     with Size => 1;
+   --  Direct AON memory access read.
+
+   type AON_CTRL_DCA_ENAB_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Direct AON memory access enable bit.
+
    type AON_CTRL_Type is record
-      RESTORE  : Types.Bits_1 := 0;
-      SAVE     : Types.Bits_1 := 0;
-      UPL_CFG  : Types.Bits_1 := 0;
-      DCA_READ : Types.Bits_1 := 0;
-      DCA_ENAB : Types.Bits_1 := 0;
+      RESTORE  : AON_CTRL_RESTORE_Field  := No_Action;
+      SAVE     : AON_CTRL_SAVE_Field     := No_Action;
+      UPL_CFG  : AON_CTRL_UPL_CFG_Field  := No_Action;
+      DCA_READ : AON_CTRL_DCA_READ_Field := No_Action;
+      DCA_ENAB : AON_CTRL_DCA_ENAB_Field := Disabled;
 
       Reserved : Types.Bits_3 := 0;
    end record
@@ -2680,7 +2767,10 @@ is
       DCA_ENAB at 0 range 7 .. 7;
    end record;
 
-   -- AON_RDAT sub-register
+   ----------------------------
+   -- AON_RDAT sub-register  --
+   ----------------------------
+
    type AON_RDAT_Type is record
       AON_RDAT : Types.Bits_8;
    end record
@@ -2692,9 +2782,14 @@ is
       AON_RDAT at 0 range 0 .. 7;
    end record;
 
-   -- AON_ADDR sub-register
+   ----------------------------
+   -- AON_ADDR sub-register  --
+   ----------------------------
+
+   type AON_ADDR_Field is new Bits_8;
+
    type AON_ADDR_Type is record
-      AON_ADDR : Types.Bits_8;
+      AON_ADDR : AON_ADDR_Field;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -2704,15 +2799,57 @@ is
       AON_ADDR at 0 range 0 .. 7;
    end record;
 
-   -- AON_CFG0 sub-register
+   ----------------------------
+   -- AON_CFG0 sub-register  --
+   ----------------------------
+
+   type AON_CFG0_SLEEP_EN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This is the sleep enable configuration bit.
+
+   type AON_CFG0_WAKE_PIN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Wake using WAKEUP pin.
+
+   type AON_CFG0_WAKE_SPI_Pin_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Wake using SPI access.
+
+   type AON_CFG0_WAKE_CNT_Pin_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Wake when sleep counter elapses.
+
+   type AON_CFG0_LPDIV_EN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Low power divider enable configuration.
+
+   type AON_CFG0_LPCLKDIVA_Field is range 0 .. 2**11 - 1
+     with Size => 11;
+   --  This field specifies a divider count for dividing the raw DW1000 XTAL
+   --  oscillator frequency to set an LP clock frequency.
+
+   type AON_CFG0_SLEEP_TIM_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  Sleep time.
+
    type AON_CFG0_Type is record
-      SLEEP_EN  : Types.Bits_1  := 0;
-      WAKE_PIN  : Types.Bits_1  := 1;
-      WAKE_SPI  : Types.Bits_1  := 1;
-      WAKE_CNT  : Types.Bits_1  := 1;
-      LPDIV_EN  : Types.Bits_1  := 0;
-      LPCLKDIVA : Types.Bits_11 := 2#000_1111_1111#;
-      SLEEP_TIM : Types.Bits_16 := 2#0101_0000_1111_1111#;
+      SLEEP_EN  : AON_CFG0_SLEEP_EN_Field     := Disabled;
+      WAKE_PIN  : AON_CFG0_WAKE_PIN_Field     := Enabled;
+      WAKE_SPI  : AON_CFG0_WAKE_SPI_Pin_Field := Enabled;
+      WAKE_CNT  : AON_CFG0_WAKE_CNT_Pin_Field := Enabled;
+      LPDIV_EN  : AON_CFG0_LPDIV_EN_Field     := Disabled;
+      LPCLKDIVA : AON_CFG0_LPCLKDIVA_Field    := 255;
+      SLEEP_TIM : AON_CFG0_SLEEP_TIM_Field    := 20735;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -2728,11 +2865,34 @@ is
       SLEEP_TIM at 0 range 16 .. 31;
    end record;
 
-   -- AON_CFG1 sub-register
+   ----------------------------
+   -- AON_CFG1 sub-register  --
+   ----------------------------
+
+   type AON_CFG1_SLEEP_CE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit enables the sleep counter.
+
+   type AON_CFG1_SMXX_Field is
+     (Clear,
+      Set)
+     with Size => 1;
+   --  This bit needs to be Cleared for correct operation in the SLEEP state
+   --  within the DW1000. By default this bit is Set.
+
+   type AON_CFG1_LPOSC_C_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  This bit enables the calibration function that measures the period of the
+   --  IC's internal low powered oscillator
+
    type AON_CFG1_Type is record
-      SLEEP_CE : Types.Bits_1 := 1;
-      SMXX     : Types.Bits_1 := 1;
-      LPOSC_C  : Types.Bits_1 := 1;
+      SLEEP_CE : AON_CFG1_SLEEP_CE_Field := Enabled;
+      SMXX     : AON_CFG1_SMXX_Field     := Set;
+      LPOSC_C  : AON_CFG1_LPOSC_C_Field  := Enabled;
 
       Reserved : Types.Bits_13 := 0;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -785,11 +785,27 @@ is
    ----------------------------------------------------------------------------
    -- RX_FQUAL register file
 
+   type RX_FQUAL_STD_NOISE_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  Standard Deviation of Noise.
+
+   type RX_FQUAL_FP_AMPL2_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  First Path Amplitude point 2.
+
+   type RX_FQUAL_FP_AMPL3_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  First Path Amplitude point 3.
+
+   type RX_FQUAL_CIR_PWR_Field is range 0 .. 2**16 - 1
+     with Size => 16;
+   --  Channel Impulse Response Power.
+
    type RX_FQUAL_Type is record
-      STD_NOISE : Types.Bits_16 := 0;
-      FP_AMPL2  : Types.Bits_16 := 0;
-      FP_AMPL3  : Types.Bits_16 := 0;
-      CIR_PWR   : Types.Bits_16 := 0;
+      STD_NOISE : RX_FQUAL_STD_NOISE_Field := 0;
+      FP_AMPL2  : RX_FQUAL_FP_AMPL2_Field  := 0;
+      FP_AMPL3  : RX_FQUAL_FP_AMPL3_Field  := 0;
+      CIR_PWR   : RX_FQUAL_CIR_PWR_Field   := 0;
    end record
      with Size => 64,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -939,6 +939,111 @@ is
    end record;
 
    ----------------------------------------------------------------------------
+   --  SYS_STATE register file
+
+   type SYS_STATE_TX_STATE_Field is
+     (Idle,
+      Preamble,
+      SFD,
+      PHR,
+      SDE,
+      DATA,
+      Reserved_0110,
+      Reserved_0111,
+      Reserved_1000,
+      Reserved_1001,
+      Reserved_1010,
+      Reserved_1011,
+      Reserved_1100,
+      Reserved_1101,
+      Reserved_1110,
+      Reserved_1111)
+     with Size => 4;
+   --  Current Transmit State Machine value
+
+   type SYS_STATE_RX_STATE_Field is
+     (Idle,
+      Start_Analog,
+      Reserved_00010,
+      Reserved_00011,
+      Rx_Ready,
+      Preamble_Search,
+      Preamble_Timeout,
+      SFD_Search,
+      Configure_PHR_Rx,
+      PHY_Rx_Start,
+      Data_Rate_Ready,
+      Reserved_01011,
+      Data_Rx_Seq,
+      Configure_Data_Rx,
+      PHR_Not_OK,
+      Last_Symbol,
+      Wait_RSD_Done,
+      RSD_OK,
+      RSD_Not_OK,
+      Reconfigure_110K,
+      Wait_110K_PHR,
+      Reserved_10101,
+      Reserved_10110,
+      Reserved_10111,
+      Reserved_11000,
+      Reserved_11001,
+      Reserved_11010,
+      Reserved_11011,
+      Reserved_11100,
+      Reserved_11101,
+      Reserved_11110,
+      Reserved_11111)
+     with Size => 5;
+   --  Current Receive State Machine value
+
+   type SYS_STATE_PMSC_STATE_Field is
+     (Init,
+      Idle,
+      TX_Wait,
+      RX_Wait,
+      Tx,
+      Rx,
+      Reserved_0110,
+      Reserved_0111,
+      Reserved_1000,
+      Reserved_1001,
+      Reserved_1010,
+      Reserved_1011,
+      Reserved_1100,
+      Reserved_1101,
+      Reserved_1110,
+      Reserved_1111)
+     with Size => 4;
+
+   type SYS_STATE_Type is record
+      TX_STATE   : SYS_STATE_TX_STATE_Field   := Idle;
+      RX_STATE   : SYS_STATE_RX_STATE_Field   := Idle;
+      PMSC_STATE : SYS_STATE_PMSC_STATE_Field := Idle;
+
+      Reserved_1 : Bits_4  := 0;
+      Reserved_2 : Bits_3  := 0;
+      Reserved_3 : Bits_12 := 0;
+   end record
+     with Size => 32,
+     Bit_Order => System.Low_Order_First,
+     Scalar_Storage_Order => System.Low_Order_First;
+
+   for SYS_STATE_Type use record
+      TX_STATE   at 0 range 0 .. 3;
+
+      Reserved_1 at 0 range 4 .. 7;
+
+      RX_STATE   at 0 range 8 .. 12;
+
+      Reserved_2 at 0 range 13 .. 15;
+
+      PMSC_STATE at 0 range 16 .. 19;
+
+      Reserved_3 at 0 range 20 .. 31;
+   end record;
+
+   ----------------------------------------------------------------------------
    -- ACK_RESP_T register file
 
    type ACK_RESP_T_Type is record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -1071,9 +1071,13 @@ is
    ----------------------------------------------------------------------------
    -- RX_SNIFF register file
 
+   type RX_SNIFF_SNIFF_ONT_Field is range 0 .. 15
+     with Size => 4;
+   --  SNIFF Mode ON time. This parameter is specified in units of PAC.
+
    type RX_SNIFF_Type is record
-      SNIFF_ONT  : Types.Bits_4  := 0;
-      SNIFF_OFFT : Types.Bits_8  := 0;
+      SNIFF_ONT  : RX_SNIFF_SNIFF_ONT_Field   := 0;
+      SNIFF_OFFT : System_Time.Sniff_Off_Time := 0.0;
 
       Reserved_1 : Types.Bits_4  := 0;
       Reserved_2 : Types.Bits_16 := 0;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -20,7 +20,8 @@
 --  DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 
-with DW1000.Types; use DW1000.Types;
+with DW1000.System_Time;
+with DW1000.Types;       use DW1000.Types;
 with System;
 
 --  This package defines types for each of the DW1000 registers.
@@ -294,7 +295,7 @@ is
    -- SYS_TIME register file
 
    type SYS_TIME_Type is record
-      SYS_TIME : Types.Bits_40;
+      SYS_TIME : System_Time.Coarse_System_Time;
    end record
      with Pack, Size => 40,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -2539,9 +2539,21 @@ is
    ----------------------------------------------------------------------------
    -- FS_CTRL register file
 
-   -- FS_PLLCFG sub-register
+   -----------------------------
+   -- FS_PLLCFG sub-register  --
+   -----------------------------
+
+   type FS_PLLCFG_Field is new Bits_32;
+
+   FS_PLLCFG_Channel_1 : constant FS_PLLCFG_Field := 16#09000407#;
+   FS_PLLCFG_Channel_2 : constant FS_PLLCFG_Field := 16#08400508#;
+   FS_PLLCFG_Channel_3 : constant FS_PLLCFG_Field := 16#08401009#;
+   FS_PLLCFG_Channel_4 : constant FS_PLLCFG_Field := 16#08400508#;
+   FS_PLLCFG_Channel_5 : constant FS_PLLCFG_Field := 16#0800041D#;
+   FS_PLLCFG_Channel_7 : constant FS_PLLCFG_Field := 16#0800041D#;
+
    type FS_PLLCFG_Type is record
-      FS_PLLCFG : Types.Bits_32;
+      FS_PLLCFG : FS_PLLCFG_Field;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,
@@ -2551,9 +2563,21 @@ is
       FS_PLLCFG at 0 range 0 .. 31;
    end record;
 
-   -- FS_PLLTUNE sub-register
+   ------------------------------
+   -- FS_PLLTUNE sub-register  --
+   ------------------------------
+
+   type FS_PLLTUNE_Field is new Bits_8;
+
+   FS_PLLTUNE_Channel_1 : constant FS_PLLTUNE_Field := 16#1E#;
+   FS_PLLTUNE_Channel_2 : constant FS_PLLTUNE_Field := 16#26#;
+   FS_PLLTUNE_Channel_3 : constant FS_PLLTUNE_Field := 16#56#;
+   FS_PLLTUNE_Channel_4 : constant FS_PLLTUNE_Field := 16#26#;
+   FS_PLLTUNE_Channel_5 : constant FS_PLLTUNE_Field := 16#BE#;
+   FS_PLLTUNE_Channel_7 : constant FS_PLLTUNE_Field := 16#BE#;
+
    type FS_PLLTUNE_Type is record
-      FS_PLLTUNE : Types.Bits_8;
+      FS_PLLTUNE : FS_PLLTUNE_Field;
    end record
      with Size => 8,
      Bit_Order => System.Low_Order_First,
@@ -2563,9 +2587,16 @@ is
       FS_PLLTUNE at 0 range 0 .. 7;
    end record;
 
-   -- FS_XTALT sub-register
+   ----------------------------
+   -- FS_XTALT sub-register  --
+   ----------------------------
+
+   type FS_XTALT_Field is range 0 .. 2**5 - 1
+     with Size => 5;
+   --  Crystal Trim.
+
    type FS_XTALT_Type is record
-      XTALT    : Types.Bits_5 := 0;
+      XTALT    : FS_XTALT_Field := 0;
 
       Reserved : Types.Bits_3 := 2#011#;
    end record

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -84,30 +84,172 @@ is
    ----------------------------------------------------------------------------
    -- SYS_CFG register file
 
+   type SYS_CFG_FFEN_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Frame Filtering Enable.
+
+   type SYS_CFG_FFBC_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Frame Filtering Behave as a Coordinator.
+
+   type SYS_CFG_FFAB_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow Beacon frame reception.
+
+   type SYS_CFG_FFAD_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow Data frame reception.
+
+   type SYS_CFG_FFAA_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow Acknowledgment frame reception.
+
+   type SYS_CFG_FFAM_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow MAC command frame reception.
+
+   type SYS_CFG_FFAR_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow Reserved frame types.
+
+   type SYS_CFG_FFA4_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow frames with frame type field of 4, (binary 100).
+
+   type SYS_CFG_FFA5_Field is
+     (Not_Allowed,
+      Allowed)
+     with Size => 1;
+   --  Frame Filtering Allow frames with frame type field of 5, (binary 101).
+
+   type SYS_CFG_HIRQ_Pol_Field is
+     (Active_Low,
+      Active_High)
+     with Size => 1;
+   --  Host interrupt polarity.
+
+   type SYS_CFG_SPI_EDGE_Field is
+     (Sampling_Edge,
+      Opposite_Edge)
+     with Size => 1;
+   --  SPI data launch edge.
+
+   type SYS_CFG_DIS_FCE_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+   --  Disable frame check error handling.
+
+   type SYS_CFG_DIS_DRXB_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+   --  Disable Double RX Buffer.
+
+   type SYS_CFG_DIS_PHE_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+   --  Disable receiver abort on PHR error.
+
+   type SYS_CFG_DIS_RSDE_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+   --  Disable Receiver Abort on RSD (Reed-Solomon Decoder) error.
+
+   type SYS_CFG_FCS_INIT2F_Field is
+     (All_Zeroes,
+      All_Ones)
+     with Size => 1;
+   --  This bit allows selection of the initial seed value for the FCS
+   --  generation and checking function that is set at the start of each frame
+   --  transmission and reception.
+
+   type SYS_CFG_PHR_MODE_Field is
+     (Standard_Frames_Mode,
+      Reserved_01,
+      Reserved_10,
+      Long_Frames_Mode)
+     with Size => 2;
+   --  Standard (max. 127 octets) or long (max. 1023 octets) frames.
+
+   type SYS_CFG_DIS_STXP_Field is
+     (Not_Disabled,
+      Disabled)
+     with Size => 1;
+   --  Disable Smart TX Power control.
+
+   type SYS_CFG_RXM110K_Field is
+     (SFD_850K_6M8,
+      SFD_110K)
+     with Size => 1;
+   --  Receiver Mode 110 kbps data rate.
+
+   type SYS_CFG_RXWTOE_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Receive Wait Timeout Enable.
+
+   type SYS_CFG_RXAUTR_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Receiver Auto-Re-enable.
+
+   type SYS_CFG_AUTOACK_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Automatic Acknowledgement Enable.
+
+   type SYS_CFG_AACKPEND_Field is
+     (Disabled,
+      Enabled)
+     with Size => 1;
+   --  Automatic Acknowledgement Pending bit control.
+
    type SYS_CFG_Type is record
-      FFEN       : Types.Bits_1 := 0;
-      FFBC       : Types.Bits_1 := 0;
-      FFAB       : Types.Bits_1 := 0;
-      FFAD       : Types.Bits_1 := 0;
-      FFAA       : Types.Bits_1 := 0;
-      FFAM       : Types.Bits_1 := 0;
-      FFAR       : Types.Bits_1 := 0;
-      FFA4       : Types.Bits_1 := 0;
-      FFA5       : Types.Bits_1 := 0;
-      HIRQ_POL   : Types.Bits_1 := 1;
-      SPI_EDGE   : Types.Bits_1 := 0;
-      DIS_FCE    : Types.Bits_1 := 0;
-      DIS_DRXB   : Types.Bits_1 := 1;
-      DIS_PHE    : Types.Bits_1 := 0;
-      DIS_RSDE   : Types.Bits_1 := 0;
-      FCS_INT2F  : Types.Bits_1 := 0;
-      PHR_MODE   : Types.Bits_2 := 0;
-      DIS_STXP   : Types.Bits_1 := 0;
-      RXM110K    : Types.Bits_1 := 0;
-      RXWTOE     : Types.Bits_1 := 0;
-      RXAUTR     : Types.Bits_1 := 0;
-      AUTOACK    : Types.Bits_1 := 0;
-      AACKPEND   : Types.Bits_1 := 0;
+      FFEN       : SYS_CFG_FFEN_Field       := Disabled;
+      FFBC       : SYS_CFG_FFBC_Field       := Disabled;
+      FFAB       : SYS_CFG_FFAB_Field       := Not_Allowed;
+      FFAD       : SYS_CFG_FFAD_Field       := Not_Allowed;
+      FFAA       : SYS_CFG_FFAA_Field       := Not_Allowed;
+      FFAM       : SYS_CFG_FFAM_Field       := Not_Allowed;
+      FFAR       : SYS_CFG_FFAR_Field       := Not_Allowed;
+      FFA4       : SYS_CFG_FFA4_Field       := Not_Allowed;
+      FFA5       : SYS_CFG_FFA5_Field       := Not_Allowed;
+      HIRQ_POL   : SYS_CFG_HIRQ_Pol_Field   := Active_High;
+      SPI_EDGE   : SYS_CFG_SPI_EDGE_Field   := Sampling_Edge;
+      DIS_FCE    : SYS_CFG_DIS_FCE_Field    := Not_Disabled;
+      DIS_DRXB   : SYS_CFG_DIS_DRXB_Field   := Disabled;
+      DIS_PHE    : SYS_CFG_DIS_PHE_Field    := Not_Disabled;
+      DIS_RSDE   : SYS_CFG_DIS_RSDE_Field   := Not_Disabled;
+      FCS_INT2F  : SYS_CFG_FCS_INIT2F_Field := All_Zeroes;
+      PHR_MODE   : SYS_CFG_PHR_MODE_Field   := Standard_Frames_Mode;
+      DIS_STXP   : SYS_CFG_DIS_STXP_Field   := Not_Disabled;
+      RXM110K    : SYS_CFG_RXM110K_Field    := SFD_850K_6M8;
+      RXWTOE     : SYS_CFG_RXWTOE_Field     := Disabled;
+      RXAUTR     : SYS_CFG_RXAUTR_Field     := Disabled;
+      AUTOACK    : SYS_CFG_AUTOACK_Field    := Disabled;
+      AACKPEND   : SYS_CFG_AACKPEND_Field   := Disabled;
 
       Reserved_1 : Types.Bits_3 := 0;
       Reserved_2 : Types.Bits_5 := 0;

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -821,8 +821,12 @@ is
    ----------------------------------------------------------------------------
    -- RX_TTCKI register file
 
+   type RX_TTCKI_RXTTCKI_Field is range 0 .. 2**32 - 1
+     with Size => 32;
+   --  RX time tracking interval.
+
    type RX_TTCKI_Type is record
-      RXTTCKI : Types.Bits_32 := 0;
+      RXTTCKI : RX_TTCKI_RXTTCKI_Field := 0;
    end record
      with Size => 32,
      Bit_Order => System.Low_Order_First,

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -401,7 +401,7 @@ is
    -- DX_TIME register file
 
    type DX_TIME_Type is record
-      DX_TIME : Types.Bits_40;
+      DX_TIME : System_Time.Coarse_System_Time := 0.0;
    end record
      with Pack, Size => 40,
      Bit_Order => System.Low_Order_First,
@@ -411,7 +411,7 @@ is
    -- RX_FWTO register file
 
    type RX_FWTO_Type is record
-      RXFWTO : Types.Bits_16 := 0;
+      RXFWTO : System_Time.Frame_Wait_Timeout_Time := 0.0;
    end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
@@ -424,16 +424,70 @@ is
    ----------------------------------------------------------------------------
    -- SYS_CTRL register file
 
+   type SYS_CTRL_SFCST_Field is
+     (Not_Suppressed,
+      Suppressed)
+     with Size => 1;
+   --  Suppress auto-FCS Transmission (on this next frame).
+
+   type SYS_CTRL_TXSTRT_Field is
+     (No_Action,
+      Start_Tx)
+     with Size => 1;
+   --  Transmit Start.
+
+   type SYS_CTRL_TXDLYS_Field is
+     (Not_Delayed,
+      Delayed)
+     with Size => 1;
+   --  Transmitter Delayed Sending.
+
+   type SYS_CTRL_CANSFCS_Field is
+     (Not_Cancelled,
+      Cancelled)
+     with Size => 1;
+   --  Cancel Suppression of auto-FCS transmission (on the current frame).
+
+   type SYS_CTRL_TRXOFF_Field is
+     (No_Action,
+      Transceiver_Off)
+     with Size => 1;
+   --  Transceiver Off.
+
+   type SYS_CTRL_WAIT4RESP_Field is
+     (No_Wait,
+      Wait)
+     with Size => 1;
+   --  Wait for Response.
+
+   type SYS_CTRL_RXENAB_Field is
+     (No_Action,
+      Start_Rx)
+     with Size => 1;
+   --  Enable Receiver.
+
+   type SYS_CTRL_RXDLYE_Field is
+     (Not_Delayed,
+      Delayed)
+     with Size => 1;
+   --  Receiver Delayed Enable.
+
+   type SYS_CTRL_HRBPT_Field is
+     (No_Action,
+      Toggle)
+     with Size => 1;
+   --  Host Side Receive Buffer Pointer Toggle.
+
    type SYS_CTRL_Type is record
-      SFCST     : Types.Bits_1   := 0;
-      TXSTRT    : Types.Bits_1   := 0;
-      TXDLYS    : Types.Bits_1   := 0;
-      CANSFCS   : Types.Bits_1   := 0;
-      TRXOFF    : Types.Bits_1   := 0;
-      WAIT4RESP : Types.Bits_1   := 0;
-      RXENAB    : Types.Bits_1   := 0;
-      RXDLYE    : Types.Bits_1   := 0;
-      HRBPT     : Types.Bits_1   := 0;
+      SFCST     : SYS_CTRL_SFCST_Field     := Not_Suppressed;
+      TXSTRT    : SYS_CTRL_TXSTRT_Field    := No_Action;
+      TXDLYS    : SYS_CTRL_TXDLYS_Field    := Not_Delayed;
+      CANSFCS   : SYS_CTRL_CANSFCS_Field   := Not_Cancelled;
+      TRXOFF    : SYS_CTRL_TRXOFF_Field    := No_Action;
+      WAIT4RESP : SYS_CTRL_WAIT4RESP_Field := No_Wait;
+      RXENAB    : SYS_CTRL_RXENAB_Field    := No_Action;
+      RXDLYE    : SYS_CTRL_RXDLYE_Field    := Not_Delayed;
+      HRBPT     : SYS_CTRL_HRBPT_Field     := No_Action;
 
       Reserved_1 : Types.Bits_2  := 0;
       Reserved_2 : Types.Bits_14 := 0;

--- a/src/dw1000-registers.ads
+++ b/src/dw1000-registers.ads
@@ -132,11 +132,13 @@ is
    RF_STATUS_Sub_Reg_ID  : constant Types.Bits_15 := 16#2C#;
    LDOTUNE_Sub_Reg_ID    : constant Types.Bits_15 := 16#30#;
 
-   TC_SARC_Sub_Reg_ID    : constant Types.Bits_15 := 16#00#;
-   TC_SARL_Sub_Reg_ID    : constant Types.Bits_15 := 16#03#;
-   TC_SARW_Sub_Reg_ID    : constant Types.Bits_15 := 16#06#;
-   TC_PGDELAY_Sub_Reg_ID : constant Types.Bits_15 := 16#0B#;
-   TC_PGTEST_Sub_Reg_ID  : constant Types.Bits_15 := 16#0C#;
+   TC_SARC_Sub_Reg_ID      : constant Types.Bits_15 := 16#00#;
+   TC_SARL_Sub_Reg_ID      : constant Types.Bits_15 := 16#03#;
+   TC_SARW_Sub_Reg_ID      : constant Types.Bits_15 := 16#06#;
+   TC_PG_CTRL_Sub_Reg_ID   : constant Types.Bits_15 := 16#08#;
+   TC_PG_STATUS_Sub_Reg_ID : constant Types.Bits_15 := 16#09#;
+   TC_PGDELAY_Sub_Reg_ID   : constant Types.Bits_15 := 16#0B#;
+   TC_PGTEST_Sub_Reg_ID    : constant Types.Bits_15 := 16#0C#;
 
    FS_PLLCFG_Sub_Reg_ID  : constant Types.Bits_15 := 16#07#;
    FS_PLLTUNE_Sub_Reg_ID : constant Types.Bits_15 := 16#0B#;
@@ -466,6 +468,16 @@ is
      (Register_Type => DW1000.Register_Types.TC_SARW_Type,
       Register_ID   => TX_CAL_Reg_ID,
       Sub_Register  => TC_SARW_Sub_Reg_ID);
+
+   package TC_PG_CTRL is new DW1000.Generic_RO_Register_Driver
+     (Register_Type => DW1000.Register_Types.TC_PG_CTRL_Type,
+      Register_ID   => TX_CAL_Reg_ID,
+      Sub_Register  => TC_PG_CTRL_Sub_Reg_ID);
+
+   package TC_PG_STATUS is new DW1000.Generic_RW_Register_Driver
+     (Register_Type => DW1000.Register_Types.TC_PG_STATUS_Type,
+      Register_ID   => TX_CAL_Reg_ID,
+      Sub_Register  => TC_PG_STATUS_Sub_Reg_ID);
 
    package TC_PGDELAY is new DW1000.Generic_RW_Register_Driver
      (Register_Type => DW1000.Register_Types.TC_PGDELAY_Type,

--- a/src/dw1000-registers.ads
+++ b/src/dw1000-registers.ads
@@ -269,6 +269,10 @@ is
      (Register_Type => DW1000.Register_Types.TX_ANTD_Type,
       Register_ID   => TX_ANTD_Reg_ID);
 
+   package SYS_STATE is new DW1000.Generic_RO_Register_Driver
+     (Register_Type => DW1000.Register_Types.SYS_STATUS_Type,
+      Register_ID   => SYS_STATE_Reg_ID);
+
    package ACK_RESP_T is new DW1000.Generic_RW_Register_Driver
      (Register_Type => DW1000.Register_Types.ACK_RESP_T_Type,
       Register_ID   => ACK_RESP_T_Reg_ID);

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -180,6 +180,31 @@ is
    --  The resolution of this type is 128 system block cycle
    --  (about 1 microsecond).
 
+   type Snooze_Time is
+   delta 1.0 / 37_500.0
+   range 0.0 .. (2.0**8 - 1.0) / 37_500.0
+     with Small => 1.0 / 37_500.0,
+     Size => 8;
+   --  Type to represent the snooze time (in seconds).
+   --
+   --  This represents the upper 8 bits of a 17-bit timer clocked from the
+   --  19.2 MHz XTI internal clock. This means that this snooze time value
+   --  is in units of 37.5 KHz, i.e. about 26.7 microseconds.
+   --
+   --  The maximum value of this type is 0.0068 (6.8 milliseconds).
+
+   type Blink_Time is
+   delta 0.014
+   range 0.0 .. (2.0**8 - 1.0) * 0.014
+     with Small => 0.014,
+     Size => 8;
+   --  Type to represent the LED blink time (in seconds).
+   --
+   --  This is in units of 14 milliseconds, so a value of 0.4 will give a
+   --  blink time of 400 ms followed by an off blink of 400 ms.
+   --
+   --  The maximum value of this type is 3.57 seconds.
+
    function To_Bits_40 (Time : in Fine_System_Time) return Bits_40 is
      (Bits_40 (Time / Fine_System_Time (Fine_System_Time'Delta)));
    --  Convert a Fine_System_Time value to its equivalent Bits_40

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -92,7 +92,8 @@ is
    type Fine_System_Time is
    delta 1.0 / System_Time_Clock_Hz
    range 0.0 .. (2.0**40 - 1.0) / System_Time_Clock_Hz
-     with Small => 1.0 / System_Time_Clock_Hz;
+     with Small => 1.0 / System_Time_Clock_Hz,
+     Size => 40;
    --  Type for representing the DW1000 fine-grained system time in seconds,
    --  with a precision of at least 15.65 picoseconds.
    --
@@ -112,7 +113,8 @@ is
    type Coarse_System_Time is
    delta 512.0 / System_Time_Clock_Hz
    range 0.0 .. (2.0**40 - 1.0) / System_Time_Clock_Hz
-     with Small => 512.0 / System_Time_Clock_Hz;
+     with Small => 1.0 / System_Time_Clock_Hz,
+     Size => 40;
    --  Type for representing the DW1000 coarsely-grained system time in seconds,
    --  with a precision of at least 8.013 nanoseconds.
    --
@@ -132,14 +134,18 @@ is
 
    type System_Time_Span is new Fine_System_Time;
 
-   subtype Antenna_Delay_Time is Fine_System_Time
-   range 0.0 .. Fine_System_Time'Delta * (2**16 - 1);
+   type Antenna_Delay_Time is
+   delta Fine_System_Time'Delta
+   range 0.0 .. Fine_System_Time'Delta * (2**16 - 1)
+     with Small => Fine_System_Time'Small,
+     Size => 16;
    --  Type to represent an antenna delay time.
 
    type Frame_Wait_Timeout_Time is
    delta 512.0 / Chipping_Rate_Hz
    range 0.0 .. ((2.0**16 - 1.0) * 512.0) / Chipping_Rate_Hz
-     with Small => 512.0 / 499_200_000.0;
+     with Small => 512.0 / 499_200_000.0,
+     Size => 16;
    --  Type to represent the frame wait timeout.
    --
    --  The range of this type is 0.0 .. 0.067215385, i.e. the maximum value

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -150,6 +150,9 @@ is
    --
    --  The range of this type is 0.0 .. 0.067215385, i.e. the maximum value
    --  is 67.215385 milliseconds.
+   --
+   --  The resolution of this type is 128 system block cycle
+   --  (about 1 microsecond).
 
    type Response_Wait_Timeout_Time is
    delta 512.0 / Chipping_Rate_Hz
@@ -161,7 +164,21 @@ is
    --  The range of this type is 0.0 .. 1.0754615 i.e. the maximum value is
    --  about 1.0754615 seconds.
    --
-   --  The resolution of this type is about 1 microsecond.
+   --  The resolution of this type is 128 system block cycle
+   --  (about 1 microsecond).
+
+   type Sniff_Off_Time is
+   delta 512.0 / Chipping_Rate_Hz
+   range 0.0 .. ((2.0**8 - 1.0) * 512.0) / Chipping_Rate_Hz
+     with Small => 512.0 / Chipping_Rate_Hz,
+     Size => 8;
+   --  Type to represent the SNIFF mode OFF time.
+   --
+   --  The range of this type is 0.0 .. 0.000_262_051 i.e. the maximum value is
+   --  about 0.000_262_051 seconds (about 262 microseconds).
+   --
+   --  The resolution of this type is 128 system block cycle
+   --  (about 1 microsecond).
 
    function To_Bits_40 (Time : in Fine_System_Time) return Bits_40 is
      (Bits_40 (Time / Fine_System_Time (Fine_System_Time'Delta)));

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -144,12 +144,24 @@ is
    type Frame_Wait_Timeout_Time is
    delta 512.0 / Chipping_Rate_Hz
    range 0.0 .. ((2.0**16 - 1.0) * 512.0) / Chipping_Rate_Hz
-     with Small => 512.0 / 499_200_000.0,
+     with Small => 512.0 / Chipping_Rate_Hz,
      Size => 16;
    --  Type to represent the frame wait timeout.
    --
    --  The range of this type is 0.0 .. 0.067215385, i.e. the maximum value
    --  is 67.215385 milliseconds.
+
+   type Response_Wait_Timeout_Time is
+   delta 512.0 / Chipping_Rate_Hz
+   range 0.0 .. ((2.0**20 - 1.0) * 512.0) / Chipping_Rate_Hz
+     with Small => 512.0 / Chipping_Rate_Hz,
+     Size => 20;
+   --  Type to represent the wait-for-response turnaround time.
+   --
+   --  The range of this type is 0.0 .. 1.0754615 i.e. the maximum value is
+   --  about 1.0754615 seconds.
+   --
+   --  The resolution of this type is about 1 microsecond.
 
    function To_Bits_40 (Time : in Fine_System_Time) return Bits_40 is
      (Bits_40 (Time / Fine_System_Time (Fine_System_Time'Delta)));


### PR DESCRIPTION
This adds better type definitions for the register fields in the DW1000 register set. Currently, the `Bits_xx` types are used for the register fields which means the user code must use "magic numbers" to set the fields to the correct value for what the user wants to do. This is not ideal.

These new field types make the code using the DW1000 registers more readable.

For example, the previous code:
```Ada
SYS_CFG_Reg.RXM110K := 1;
```
becomes:
```Ada
SYS_CFG_Reg.RXM110K := SFD_110K;
```

Additionally, the System_Time types are now used directly in the relevant register types. This avoids needing to perform conversions from `Bits_40` to `Fine_System_Time` or `Coarse_System_Time` and other time types. Representation clauses for these fixed-point types ('Small and 'Size) ensure that the underlying representation of these types matches the DW1000 register values.