### PR TITLE
Enable style checks and warnings in example projects.

### DIFF
--- a/bsp-examples/dwm1001/dw1000-bsp.adb
+++ b/bsp-examples/dwm1001/dw1000-bsp.adb
@@ -78,8 +78,7 @@ is
    --  give this protected object an Interrupt_Priority.
 
    protected Driver
-     with Interrupt_Priority => DecaDriver_Config.Driver_Priority
-   is
+     with Interrupt_Priority => DecaDriver_Config.Driver_Priority is
       procedure PO_Reset_DW1000;
 
       procedure PO_Get_Reset_State (State : out DW1000.Types.Bits_1);
@@ -116,8 +115,7 @@ is
       --  PO_Reset_DW1000  --
       -----------------------
 
-      procedure PO_Reset_DW1000
-      is
+      procedure PO_Reset_DW1000 is
          End_Time : Ada.Real_Time.Time;
       begin
 
@@ -151,8 +149,7 @@ is
       --  PO_Get_Reset_State  --
       --------------------------
 
-      procedure PO_Get_Reset_State (State : out DW1000.Types.Bits_1)
-      is
+      procedure PO_Get_Reset_State (State : out DW1000.Types.Bits_1) is
       begin
          if P0_Periph.IN_k.Arr (Reset_Pin) = Low then
             State := 0;
@@ -165,8 +162,7 @@ is
       --  PO_Use_Slow_SPI_Clock  --
       -----------------------------
 
-      procedure PO_Use_Slow_SPI_Clock
-      is
+      procedure PO_Use_Slow_SPI_Clock is
       begin
          --  Select fastest possible SPI speed that does not exceed 3 MHz.
          SPI1_Periph.ENABLE := (ENABLE => Disabled, others => <>);
@@ -178,8 +174,7 @@ is
       --  PO_Use_Fast_SPI_Clock  --
       -----------------------------
 
-      procedure PO_Use_Fast_SPI_Clock
-      is
+      procedure PO_Use_Fast_SPI_Clock is
       begin
          SPI1_Periph.ENABLE := (ENABLE => Disabled, others => <>);
          SPI1_Periph.FREQUENCY := SPI_Frequency_Max;
@@ -190,8 +185,7 @@ is
       --  PO_Wakeup  --
       -----------------
 
-      procedure PO_Wakeup (Wait_For_INIT : in Boolean)
-      is
+      procedure PO_Wakeup (Wait_For_INIT : in Boolean) is
          use type DW1000.Types.Bits_1;
 
          Now        : Ada.Real_Time.Time;
@@ -236,8 +230,7 @@ is
       ----------------------------
 
       procedure PO_Write_Transaction (Header : in DW1000.Types.Byte_Array;
-                                      Data   : in DW1000.Types.Byte_Array)
-      is
+                                      Data   : in DW1000.Types.Byte_Array) is
          Dummy : Byte;
 
       begin
@@ -270,8 +263,7 @@ is
       ---------------------------
 
       procedure PO_Read_Transaction (Header : in     DW1000.Types.Byte_Array;
-                                     Data   :    out DW1000.Types.Byte_Array)
-      is
+                                     Data   :    out DW1000.Types.Byte_Array) is
          Rx_Byte : Byte;
 
       begin
@@ -306,8 +298,7 @@ is
       -------------------------
 
       procedure SPI_Transfer_Byte (Tx_Byte : in     NRF52.Byte;
-                                   Rx_Byte :    out NRF52.Byte)
-      is
+                                   Rx_Byte :    out NRF52.Byte) is
       begin
          SPI1_Periph.TXD := (TXD => Tx_Byte, others => <>);
 
@@ -326,8 +317,7 @@ is
    --  Reset_DW1000  --
    --------------------
 
-   procedure Reset_DW1000
-   is
+   procedure Reset_DW1000 is
    begin
       Driver.PO_Reset_DW1000;
    end Reset_DW1000;
@@ -336,8 +326,7 @@ is
    --  Get_Reset_State  --
    -----------------------
 
-   procedure Get_Reset_State (State : out DW1000.Types.Bits_1)
-   is
+   procedure Get_Reset_State (State : out DW1000.Types.Bits_1) is
    begin
       Driver.PO_Get_Reset_State (State);
    end Get_Reset_State;
@@ -346,8 +335,7 @@ is
    --  Acknowledge_DW1000_IRQ  --
    ------------------------------
 
-   procedure Acknowledge_DW1000_IRQ
-   is
+   procedure Acknowledge_DW1000_IRQ is
    begin
       GPIOTE_Periph.EVENTS_IN (IRQ_Event) := (EVENTS_IN => 0, others => <>);
    end Acknowledge_DW1000_IRQ;
@@ -356,8 +344,7 @@ is
    --  Disable_DW1000_IRQ  --
    --------------------------
 
-   procedure Disable_DW1000_IRQ
-   is
+   procedure Disable_DW1000_IRQ is
    begin
       GPIOTE_Periph.INTENCLR.IN_k.Arr (IRQ_Event) := Clear;
    end Disable_DW1000_IRQ;
@@ -366,8 +353,7 @@ is
    --  Enable_DW1000_IRQ  --
    -------------------------
 
-   procedure Enable_DW1000_IRQ
-   is
+   procedure Enable_DW1000_IRQ is
    begin
       GPIOTE_Periph.INTENSET.IN_k.Arr (IRQ_Event) := Set;
    end Enable_DW1000_IRQ;
@@ -376,8 +362,7 @@ is
    --  Use_Slow_SPI_Clock  --
    --------------------------
 
-   procedure Use_Slow_SPI_Clock
-   is
+   procedure Use_Slow_SPI_Clock is
    begin
       Driver.PO_Use_Slow_SPI_Clock;
    end Use_Slow_SPI_Clock;
@@ -386,8 +371,7 @@ is
    --  Use_Fast_SPI_Clock  --
    --------------------------
 
-   procedure Use_Fast_SPI_Clock
-   is
+   procedure Use_Fast_SPI_Clock is
    begin
       Driver.PO_Use_Fast_SPI_Clock;
    end Use_Fast_SPI_Clock;
@@ -396,8 +380,7 @@ is
    --  Wakeup  --
    --------------
 
-   procedure Wakeup (Wait_For_INIT : in Boolean)
-   is
+   procedure Wakeup (Wait_For_INIT : in Boolean) is
    begin
       Driver.PO_Wakeup (Wait_For_INIT);
    end Wakeup;
@@ -407,8 +390,7 @@ is
    -------------------------
 
    procedure Write_Transaction (Header : in DW1000.Types.Byte_Array;
-                                Data   : in DW1000.Types.Byte_Array)
-   is
+                                Data   : in DW1000.Types.Byte_Array) is
    begin
       Driver.PO_Write_Transaction (Header, Data);
    end Write_Transaction;
@@ -418,8 +400,7 @@ is
    ------------------------
 
    procedure Read_Transaction (Header : in     DW1000.Types.Byte_Array;
-                               Data   :    out DW1000.Types.Byte_Array)
-   is
+                               Data   :    out DW1000.Types.Byte_Array) is
    begin
       Driver.PO_Read_Transaction (Header, Data);
    end Read_Transaction;
@@ -428,8 +409,7 @@ is
    --  Select_Device  --
    ---------------------
 
-   procedure Select_Device
-   is
+   procedure Select_Device is
    begin
       P0_Periph.OUTCLR := (As_Array => True,
                            Arr      => (SPI_CS_Pin => Clear,
@@ -440,8 +420,7 @@ is
    --  Deselect_Device  --
    -----------------------
 
-   procedure Deselect_Device
-   is
+   procedure Deselect_Device is
    begin
       P0_Periph.OUTSET := (As_Array => True,
                            Arr      => (SPI_CS_Pin => Set,

--- a/bsp-examples/dwm1001/dw1000-bsp.adb
+++ b/bsp-examples/dwm1001/dw1000-bsp.adb
@@ -80,25 +80,23 @@ is
    protected Driver
      with Interrupt_Priority => DecaDriver_Config.Driver_Priority
    is
-      procedure Reset_DW1000;
+      procedure PO_Reset_DW1000;
 
-      procedure Get_Reset_State (State : out DW1000.Types.Bits_1);
+      procedure PO_Get_Reset_State (State : out DW1000.Types.Bits_1);
 
-      procedure Use_Slow_SPI_Clock;
+      procedure PO_Use_Slow_SPI_Clock;
 
-      procedure Use_Fast_SPI_Clock;
+      procedure PO_Use_Fast_SPI_Clock;
 
-      procedure Wakeup (Wait_For_INIT : in Boolean);
+      procedure PO_Wakeup (Wait_For_INIT : in Boolean);
 
-      procedure Write_Transaction(Header : in DW1000.Types.Byte_Array;
-                                  Data   : in DW1000.Types.Byte_Array)
-        with Pre => (Header'Length in 1 .. 3
-                     and Data'Length > 0);
+      procedure PO_Write_Transaction (Header : in DW1000.Types.Byte_Array;
+                                      Data   : in DW1000.Types.Byte_Array)
+        with Pre => (Header'Length in 1 .. 3 and Data'Length > 0);
 
-      procedure Read_Transaction(Header : in     DW1000.Types.Byte_Array;
-                                 Data   :    out DW1000.Types.Byte_Array)
-        with Pre => (Header'Length in 1 .. 3
-                     and Data'Length > 0);
+      procedure PO_Read_Transaction (Header : in     DW1000.Types.Byte_Array;
+                                     Data   :    out DW1000.Types.Byte_Array)
+        with Pre => (Header'Length in 1 .. 3 and Data'Length > 0);
 
    private
 
@@ -114,11 +112,11 @@ is
 
    protected body Driver is
 
-      --------------------
-      --  Reset_DW1000  --
-      --------------------
+      -----------------------
+      --  PO_Reset_DW1000  --
+      -----------------------
 
-      procedure Reset_DW1000
+      procedure PO_Reset_DW1000
       is
          End_Time : Ada.Real_Time.Time;
       begin
@@ -147,13 +145,13 @@ is
                                            DRIVE  => S0S1,
                                            SENSE  => Disabled,
                                            others => <>);
-      end Reset_DW1000;
+      end PO_Reset_DW1000;
 
-      -----------------------
-      --  Get_Reset_State  --
-      -----------------------
+      --------------------------
+      --  PO_Get_Reset_State  --
+      --------------------------
 
-      procedure Get_Reset_State (State : out DW1000.Types.Bits_1)
+      procedure PO_Get_Reset_State (State : out DW1000.Types.Bits_1)
       is
       begin
          if P0_Periph.IN_k.Arr (Reset_Pin) = Low then
@@ -161,38 +159,38 @@ is
          else
             State := 1;
          end if;
-      end Get_Reset_State;
+      end PO_Get_Reset_State;
 
-      --------------------------
-      --  Use_Slow_SPI_Clock  --
-      --------------------------
+      -----------------------------
+      --  PO_Use_Slow_SPI_Clock  --
+      -----------------------------
 
-      procedure Use_Slow_SPI_Clock
+      procedure PO_Use_Slow_SPI_Clock
       is
       begin
          --  Select fastest possible SPI speed that does not exceed 3 MHz.
          SPI1_Periph.ENABLE := (ENABLE => Disabled, others => <>);
          SPI1_Periph.FREQUENCY := SPI_Frequency_2_MHz;
          SPI1_Periph.ENABLE := (ENABLE => Enabled, others => <>);
-      end Use_Slow_SPI_Clock;
+      end PO_Use_Slow_SPI_Clock;
 
-      --------------------------
-      --  Use_Fast_SPI_Clock  --
-      --------------------------
+      -----------------------------
+      --  PO_Use_Fast_SPI_Clock  --
+      -----------------------------
 
-      procedure Use_Fast_SPI_Clock
+      procedure PO_Use_Fast_SPI_Clock
       is
       begin
          SPI1_Periph.ENABLE := (ENABLE => Disabled, others => <>);
          SPI1_Periph.FREQUENCY := SPI_Frequency_Max;
          SPI1_Periph.ENABLE := (ENABLE => Enabled, others => <>);
-      end Use_Fast_SPI_Clock;
+      end PO_Use_Fast_SPI_Clock;
 
-      --------------
-      --  Wakeup  --
-      --------------
+      -----------------
+      --  PO_Wakeup  --
+      -----------------
 
-      procedure Wakeup (Wait_For_INIT : in Boolean)
+      procedure PO_Wakeup (Wait_For_INIT : in Boolean)
       is
          use type DW1000.Types.Bits_1;
 
@@ -231,14 +229,14 @@ is
             end loop;
          end if;
 
-      end Wakeup;
+      end PO_Wakeup;
 
-      -------------------------
-      --  Write_Transaction  --
-      -------------------------
+      ----------------------------
+      --  PO_Write_Transaction  --
+      ----------------------------
 
-      procedure Write_Transaction(Header : in DW1000.Types.Byte_Array;
-                                  Data   : in DW1000.Types.Byte_Array)
+      procedure PO_Write_Transaction (Header : in DW1000.Types.Byte_Array;
+                                      Data   : in DW1000.Types.Byte_Array)
       is
          Dummy : Byte;
 
@@ -265,14 +263,14 @@ is
 
          Enable_DW1000_IRQ;
 
-      end Write_Transaction;
+      end PO_Write_Transaction;
 
-      ------------------------
-      --  Read_Transaction  --
-      ------------------------
+      ---------------------------
+      --  PO_Read_Transaction  --
+      ---------------------------
 
-      procedure Read_Transaction(Header : in     DW1000.Types.Byte_Array;
-                                 Data   :    out DW1000.Types.Byte_Array)
+      procedure PO_Read_Transaction (Header : in     DW1000.Types.Byte_Array;
+                                     Data   :    out DW1000.Types.Byte_Array)
       is
          Rx_Byte : Byte;
 
@@ -301,7 +299,7 @@ is
 
          Enable_DW1000_IRQ;
 
-      end Read_Transaction;
+      end PO_Read_Transaction;
 
       -------------------------
       --  SPI_Transfer_Byte  --
@@ -331,7 +329,7 @@ is
    procedure Reset_DW1000
    is
    begin
-      Driver.Reset_DW1000;
+      Driver.PO_Reset_DW1000;
    end Reset_DW1000;
 
    -----------------------
@@ -341,7 +339,7 @@ is
    procedure Get_Reset_State (State : out DW1000.Types.Bits_1)
    is
    begin
-      Driver.Get_Reset_State (State);
+      Driver.PO_Get_Reset_State (State);
    end Get_Reset_State;
 
    ------------------------------
@@ -381,7 +379,7 @@ is
    procedure Use_Slow_SPI_Clock
    is
    begin
-      Driver.Use_Slow_SPI_Clock;
+      Driver.PO_Use_Slow_SPI_Clock;
    end Use_Slow_SPI_Clock;
 
    --------------------------
@@ -391,7 +389,7 @@ is
    procedure Use_Fast_SPI_Clock
    is
    begin
-      Driver.Use_Fast_SPI_Clock;
+      Driver.PO_Use_Fast_SPI_Clock;
    end Use_Fast_SPI_Clock;
 
    --------------
@@ -401,29 +399,29 @@ is
    procedure Wakeup (Wait_For_INIT : in Boolean)
    is
    begin
-      Driver.Wakeup (Wait_For_INIT);
+      Driver.PO_Wakeup (Wait_For_INIT);
    end Wakeup;
 
    -------------------------
    --  Write_Transaction  --
    -------------------------
 
-   procedure Write_Transaction(Header : in DW1000.Types.Byte_Array;
-                               Data   : in DW1000.Types.Byte_Array)
+   procedure Write_Transaction (Header : in DW1000.Types.Byte_Array;
+                                Data   : in DW1000.Types.Byte_Array)
    is
    begin
-      Driver.Write_Transaction (Header, Data);
+      Driver.PO_Write_Transaction (Header, Data);
    end Write_Transaction;
 
    ------------------------
    --  Read_Transaction  --
    ------------------------
 
-   procedure Read_Transaction(Header : in     DW1000.Types.Byte_Array;
-                              Data   :    out DW1000.Types.Byte_Array)
+   procedure Read_Transaction (Header : in     DW1000.Types.Byte_Array;
+                               Data   :    out DW1000.Types.Byte_Array)
    is
    begin
-      Driver.Read_Transaction (Header, Data);
+      Driver.PO_Read_Transaction (Header, Data);
    end Read_Transaction;
 
    ---------------------
@@ -449,7 +447,6 @@ is
                            Arr      => (SPI_CS_Pin => Set,
                                         others     => <>));
    end Deselect_Device;
-
 
 begin
    --  Configure GPIOs
@@ -495,7 +492,7 @@ begin
                                       others => <>);
 
    --  Configure SPI
-   SPI1_Periph.CONFIG := (ORDER  => MsbFirst,
+   SPI1_Periph.CONFIG := (ORDER  => Msbfirst,
                           CPHA   => Leading,
                           CPOL   => Activehigh,
                           others => <>);

--- a/examples/echo/echo_example.adb
+++ b/examples/echo/echo_example.adb
@@ -36,11 +36,11 @@ procedure Echo_Example
              In_Out => (DW1000.BSP.Device_State,
                         DecaDriver.Driver,
                         DecaDriver.Tx_Complete_Flag)),
-  Depends => (DecaDriver.Driver           => + (DW1000.BSP.Device_State,
-                                                DecaDriver.Driver),
-              DW1000.BSP.Device_State     => + (DecaDriver.Driver),
-              DecaDriver.Tx_Complete_Flag => + (DecaDriver.Driver,
-                                                DW1000.BSP.Device_State),
+  Depends => (DecaDriver.Driver           =>+ (DW1000.BSP.Device_State,
+                                               DecaDriver.Driver),
+              DW1000.BSP.Device_State     =>+ (DecaDriver.Driver),
+              DecaDriver.Tx_Complete_Flag =>+ (DecaDriver.Driver,
+                                               DW1000.BSP.Device_State),
               null                        => Ada.Real_Time.Clock_Time)
 is
    Rx_Packet        : DW1000.Types.Byte_Array (1 .. 127) := (others => 0);
@@ -92,7 +92,7 @@ begin
    --  so configure the DW1000 to automatically re-enable the receiver when
    --  errors occur. The driver will not be notified of receiver errors whilst
    --  this is enabled.
-   DW1000.Driver.Set_Auto_Rx_Reenable (Enabled => True);
+   DW1000.Driver.Set_Auto_Rx_Reenable (Enable => True);
 
    DecaDriver.Driver.Start_Rx_Immediate;
 

--- a/examples/echo/echo_example.gpr
+++ b/examples/echo/echo_example.gpr
@@ -37,7 +37,7 @@ project Echo_Example is
    end Builder;
 
    package Compiler is
-      for Default_Switches ("ada") use ("-gnatn", "-O2", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12");
+      for Default_Switches ("ada") use ("-gnatn", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12", "-gnatwc.cefghijklmoqrtvwxyz", "-gnaty3aAbcdefhiklL7M100nrSstu");
    end Compiler;
 
    package Linker is

--- a/examples/receive/receive_example.adb
+++ b/examples/receive/receive_example.adb
@@ -32,8 +32,8 @@ procedure Receive_Example
   Global => (Input  => Ada.Real_Time.Clock_Time,
              In_Out => (DW1000.BSP.Device_State,
                         DecaDriver.Driver)),
-  Depends => (DecaDriver.Driver         => + DW1000.BSP.Device_State,
-              DW1000.BSP.Device_State   => + DecaDriver.Driver,
+  Depends => (DecaDriver.Driver         =>+ DW1000.BSP.Device_State,
+              DW1000.BSP.Device_State   =>+ DecaDriver.Driver,
               null                      => Ada.Real_Time.Clock_Time)
 is
    Rx_Packet        : DW1000.Types.Byte_Array (1 .. 127) := (others => 0);
@@ -78,7 +78,7 @@ begin
    --  so configure the DW1000 to automatically re-enable the receiver when
    --  errors occur. The driver will not be notified of receiver errors whilst
    --  this is enabled.
-   DW1000.Driver.Set_Auto_Rx_Reenable (Enabled => True);
+   DW1000.Driver.Set_Auto_Rx_Reenable (Enable => True);
 
    --  Continuously receive packets
    loop

--- a/examples/receive/receive_example.gpr
+++ b/examples/receive/receive_example.gpr
@@ -37,7 +37,7 @@ project Receive_Example is
    end Builder;
 
    package Compiler is
-      for Default_Switches ("ada") use ("-gnatn", "-O2", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12");
+      for Default_Switches ("ada") use ("-gnatn", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12", "-gnatwc.cefghijklmoqrtvwxyz", "-gnaty3aAbcdefhiklL7M100nrSstu");
    end Compiler;
 
    package Linker is

--- a/examples/transmit/transmit_example.adb
+++ b/examples/transmit/transmit_example.adb
@@ -35,9 +35,9 @@ procedure Transmit_Example
              In_Out => (DW1000.BSP.Device_State,
                         DecaDriver.Driver,
                         DecaDriver.Tx_Complete_Flag)),
-  Depends => (DecaDriver.Driver           => + DW1000.BSP.Device_State,
-              DW1000.BSP.Device_State     => + DecaDriver.Driver,
-              DecaDriver.Tx_Complete_Flag => + null,
+  Depends => (DecaDriver.Driver           =>+ DW1000.BSP.Device_State,
+              DW1000.BSP.Device_State     =>+ DecaDriver.Driver,
+              DecaDriver.Tx_Complete_Flag =>+ null,
               null                        => Ada.Real_Time.Clock_Time)
 is
    Packet : constant DW1000.Types.Byte_Array (1 .. 10) := (others => 16#AA#);

--- a/examples/transmit/transmit_example.gpr
+++ b/examples/transmit/transmit_example.gpr
@@ -23,7 +23,7 @@ project Transmit_Example is
    end Builder;
 
    package Compiler is
-      for Default_Switches ("ada") use ("-gnatn", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12");
+      for Default_Switches ("ada") use ("-gnatn", "-ffunction-sections", "-fdata-sections", "-gnatp", "-g", "-gnat12", "-gnatwc.cefghijklmoqrtvwxyz", "-gnaty3aAbcdefhiklL7M100nrSstu");
    end Compiler;
 
    package Linker is

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -199,7 +199,7 @@ is
             DW1000.Driver.Load_LDE_From_ROM;
 
          else
-            -- Should disable LDERUN bit, since the LDE isn't loaded.
+            --  Should disable LDERUN bit, since the LDE isn't loaded.
             DW1000.Registers.PMSC_CTRL1.Read (PMSC_CTRL1_Reg);
             PMSC_CTRL1_Reg.LDERUNE := Disabled;
             DW1000.Registers.PMSC_CTRL1.Write (PMSC_CTRL1_Reg);
@@ -235,8 +235,6 @@ is
 
       procedure Configure (Config : in Configuration_Type)
       is
-         SFD_Timeout : DW1000.Driver.SFD_Timeout_Number;
-
       begin
 
          --  110 kbps data rate has special handling
@@ -259,17 +257,14 @@ is
          DW1000.Driver.Configure_PLL (Config.Channel);
          DW1000.Driver.Configure_RF (Config.Channel);
 
-         --  Don't allow a zero SFD timeout
-         SFD_Timeout := (if Config.SFD_Timeout = 0
-                         then Default_SFD_Timeout
-                         else Config.SFD_Timeout);
-
          DW1000.Driver.Configure_DRX
            (PRF                => Config.PRF,
             Data_Rate          => Config.Data_Rate,
             Tx_Preamble_Length => Config.Tx_Preamble_Length,
             PAC                => Config.Rx_PAC,
-            SFD_Timeout        => SFD_Timeout,
+            SFD_Timeout        => (if Config.SFD_Timeout = 0
+                                   then Default_SFD_Timeout
+                                   else Config.SFD_Timeout),
             Nonstandard_SFD    => Config.Use_Nonstandard_SFD);
 
          DW1000.Driver.Configure_AGC (Config.PRF);
@@ -351,18 +346,18 @@ is
       --  Configure_Errors  --
       ------------------------
 
-      procedure Configure_Errors (Frame_Timeout : in Boolean;
-                                  SFD_Timeout   : in Boolean;
-                                  PHR_Error     : in Boolean;
-                                  RS_Error      : in Boolean;
-                                  FCS_Error     : in Boolean)
+      procedure Configure_Errors (Enable_Frame_Timeout : in Boolean;
+                                  Enable_SFD_Timeout   : in Boolean;
+                                  Enable_PHR_Error     : in Boolean;
+                                  Enable_RS_Error      : in Boolean;
+                                  Enable_FCS_Error     : in Boolean)
       is
       begin
-         Detect_Frame_Timeout := Frame_Timeout;
-         Detect_SFD_Timeout   := SFD_Timeout;
-         Detect_PHR_Error     := PHR_Error;
-         Detect_RS_Error      := RS_Error;
-         Detect_FCS_Error     := FCS_Error;
+         Detect_Frame_Timeout := Enable_Frame_Timeout;
+         Detect_SFD_Timeout   := Enable_SFD_Timeout;
+         Detect_PHR_Error     := Enable_PHR_Error;
+         Detect_RS_Error      := Enable_RS_Error;
+         Detect_FCS_Error     := Enable_FCS_Error;
       end Configure_Errors;
 
       -----------------------
@@ -624,7 +619,7 @@ is
       --  Receive_Error  --
       ---------------------
 
-      procedure Receive_Error (Error : in Rx_Status_Type)
+      procedure Receive_Error (Result : in Rx_Status_Type)
       is
          Next_Idx     : Rx_Frame_Queue_Index;
 
@@ -638,7 +633,7 @@ is
             Rx_Count := Rx_Count + 1;
 
             Frame_Queue (Next_Idx).Length     := 0;
-            Frame_Queue (Next_Idx).Status     := Error;
+            Frame_Queue (Next_Idx).Status     := Result;
             Frame_Queue (Next_Idx).Overrun    := Overrun_Occurred;
             Frame_Queue (Next_Idx).Frame_Info := Null_Frame_Info;
             Overrun_Occurred := False;
@@ -743,7 +738,7 @@ is
             --  Frame sent
             Ada.Synchronous_Task_Control.Set_True (Tx_Complete_Flag);
 
-            -- Clear all TX events
+            --  Clear all TX events
             SYS_STATUS_Clear.AAT   := 1;
             SYS_STATUS_Clear.TXFRS := 1;
             SYS_STATUS_Clear.TXFRB := 1;

--- a/src/decadriver.adb
+++ b/src/decadriver.adb
@@ -56,8 +56,7 @@ is
    -------------------------
 
    function Receive_Timestamp (Frame_Info : in Frame_Info_Type)
-                               return Fine_System_Time
-   is
+                               return Fine_System_Time is
    begin
       return Frame_Info.RX_TIME_Reg.RX_STAMP;
    end Receive_Timestamp;
@@ -67,8 +66,7 @@ is
    ----------------------------
 
    function Receive_Signal_Power (Frame_Info : in Frame_Info_Type)
-                                  return Float
-   is
+                                  return Float is
       RXBR       : RX_FINFO_RXBR_Field;
       SFD_LENGTH : Bits_8;
       RXPACC     : RX_FINFO_RXPACC_Field;
@@ -102,8 +100,7 @@ is
    -------------------------------
 
    function First_Path_Signal_Power (Frame_Info : in Frame_Info_Type)
-                                     return Float
-   is
+                                     return Float is
       RXBR       : RX_FINFO_RXBR_Field;
       SFD_LENGTH : Bits_8;
       RXPACC     : RX_FINFO_RXPACC_Field;
@@ -138,8 +135,7 @@ is
    --------------------------------
 
    function Transmitter_Clock_Offset (Frame_Info : in Frame_Info_Type)
-                                      return Long_Float
-   is
+                                      return Long_Float is
    begin
       return Transmitter_Clock_Offset
         (RXTOFS  => Frame_Info.RX_TTCKO_Reg.RXTOFS,
@@ -150,8 +146,7 @@ is
    --  Driver  --
    --------------
 
-   protected body Driver
-   is
+   protected body Driver is
 
       ------------------
       --  Initialize  --
@@ -159,8 +154,7 @@ is
 
       procedure Initialize (Load_Antenna_Delay   : in Boolean;
                             Load_XTAL_Trim       : in Boolean;
-                            Load_UCode_From_ROM  : in Boolean)
-      is
+                            Load_UCode_From_ROM  : in Boolean) is
          Word : Bits_32;
 
          PMSC_CTRL1_Reg : DW1000.Register_Types.PMSC_CTRL1_Type;
@@ -233,8 +227,7 @@ is
       --  Configure  --
       -----------------
 
-      procedure Configure (Config : in Configuration_Type)
-      is
+      procedure Configure (Config : in Configuration_Type) is
       begin
 
          --  110 kbps data rate has special handling
@@ -350,8 +343,7 @@ is
                                   Enable_SFD_Timeout   : in Boolean;
                                   Enable_PHR_Error     : in Boolean;
                                   Enable_RS_Error      : in Boolean;
-                                  Enable_FCS_Error     : in Boolean)
-      is
+                                  Enable_FCS_Error     : in Boolean) is
       begin
          Detect_Frame_Timeout := Enable_Frame_Timeout;
          Detect_SFD_Timeout   := Enable_SFD_Timeout;
@@ -364,8 +356,7 @@ is
       --  Force_Tx_Rx_Off  --
       -----------------------
 
-      procedure Force_Tx_Rx_Off
-      is
+      procedure Force_Tx_Rx_Off is
       begin
          DW1000.Driver.Force_Tx_Rx_Off;
 
@@ -378,8 +369,7 @@ is
       --  Get_Part_ID  --
       -------------------
 
-      function Get_Part_ID return Bits_32
-      is
+      function Get_Part_ID return Bits_32 is
       begin
          return Part_ID;
       end Get_Part_ID;
@@ -388,8 +378,7 @@ is
       --  Get_Lot_ID  --
       ------------------
 
-      function Get_Lot_ID  return Bits_32
-      is
+      function Get_Lot_ID  return Bits_32 is
       begin
          return Lot_ID;
       end Get_Lot_ID;
@@ -398,8 +387,7 @@ is
       --  PHR_Mode  --
       ----------------
 
-      function PHR_Mode return DW1000.Driver.Physical_Header_Modes
-      is
+      function PHR_Mode return DW1000.Driver.Physical_Header_Modes is
       begin
          if Long_Frames then
             return Extended_Frames;
@@ -413,8 +401,7 @@ is
       --------------------------
 
       procedure Start_Tx_Immediate (Rx_After_Tx     : in Boolean;
-                                    Auto_Append_FCS : in Boolean)
-      is
+                                    Auto_Append_FCS : in Boolean) is
       begin
          DW1000.Driver.Start_Tx_Immediate (Rx_After_Tx, Auto_Append_FCS);
 
@@ -427,8 +414,7 @@ is
 
       procedure Start_Tx_Delayed
         (Rx_After_Tx : in     Boolean;
-         Result      :    out DW1000.Driver.Result_Type)
-      is
+         Result      :    out DW1000.Driver.Result_Type) is
       begin
          DW1000.Driver.Start_Tx_Delayed (Rx_After_Tx => Rx_After_Tx,
                                          Result      => Result);
@@ -449,8 +435,7 @@ is
                      Frame_Info :    out Frame_Info_Type;
                      Status     :    out Rx_Status_Type;
                      Overrun    :    out Boolean)
-        when Frame_Ready
-      is
+        when Frame_Ready is
       begin
          pragma Assume (Frame_Ready,
                         "barrier condition is true on entry");
@@ -489,8 +474,7 @@ is
       --  Pending_Frames_Count  --
       ----------------------------
 
-      function Pending_Frames_Count return Natural
-      is
+      function Pending_Frames_Count return Natural is
       begin
          return Rx_Count;
       end Pending_Frames_Count;
@@ -499,8 +483,7 @@ is
       --  Discard_Pending_Frames  --
       ------------------------------
 
-      procedure Discard_Pending_Frames
-      is
+      procedure Discard_Pending_Frames is
       begin
          Rx_Count := 0;
       end Discard_Pending_Frames;
@@ -509,8 +492,7 @@ is
       --  Start_Rx_Immediate  --
       --------------------------
 
-      procedure Start_Rx_Immediate
-      is
+      procedure Start_Rx_Immediate is
       begin
          DW1000.Driver.Start_Rx_Immediate;
       end Start_Rx_Immediate;
@@ -519,18 +501,16 @@ is
       --  Start_Rx_Delayed  --
       ------------------------
 
-      procedure Start_Rx_Delayed (Result  : out Result_Type)
-      is
+      procedure Start_Rx_Delayed (Result  : out Result_Type) is
       begin
-         DW1000.Driver.Start_Rx_Delayed (Result => Result);
+         DW1000.Driver.Start_Rx_Delayed (Result);
       end Start_Rx_Delayed;
 
       ----------------------
       --  Frame_Received  --
       ----------------------
 
-      procedure Frame_Received
-      is
+      procedure Frame_Received is
          RX_FINFO_Reg : DW1000.Register_Types.RX_FINFO_Type;
 
          Frame_Length : Natural;
@@ -619,8 +599,7 @@ is
       --  Receive_Error  --
       ---------------------
 
-      procedure Receive_Error (Result : in Rx_Status_Type)
-      is
+      procedure Receive_Error (Result : in Rx_Status_Type) is
          Next_Idx     : Rx_Frame_Queue_Index;
 
       begin
@@ -646,8 +625,7 @@ is
       --  DW1000_IRQ  --
       ------------------
 
-      procedure DW1000_IRQ
-      is
+      procedure DW1000_IRQ is
          SYS_STATUS_Reg : DW1000.Register_Types.SYS_STATUS_Type;
 
          SYS_STATUS_Clear : DW1000.Register_Types.SYS_STATUS_Type

--- a/src/decadriver.ads
+++ b/src/decadriver.ads
@@ -672,15 +672,14 @@ is
       Frame_Queue : Implementation.Rx_Frame_Queue_Type
         := (others => (Length     => 0,
                        Frame      => (others => 0),
-                       Frame_Info => Frame_Info_Type'
-                         (RX_TIME_Reg      => (others => <>),
-                          RX_FINFO_Reg     => (others => <>),
-                          RX_FQUAL_Reg     => (others => <>),
-                          RXPACC_NOSAT_Reg => (others => 0),
-                          RX_TTCKI_Reg     => (others => <>),
-                          RX_TTCKO_Reg     => (others => <>),
-                          SFD_LENGTH       => 0,
-                          Non_Standard_SFD => False),
+                       Frame_Info => (RX_TIME_Reg      => (others => <>),
+                                      RX_FINFO_Reg     => (others => <>),
+                                      RX_FQUAL_Reg     => (others => <>),
+                                      RXPACC_NOSAT_Reg => (others => 0),
+                                      RX_TTCKI_Reg     => (others => <>),
+                                      RX_TTCKO_Reg     => (others => <>),
+                                      SFD_LENGTH       => 0,
+                                      Non_Standard_SFD => False),
                        Status     => No_Error,
                        Overrun    => False));
       --  Cyclic buffer for storing received frames, read from the DW1000.

--- a/src/decadriver.ads
+++ b/src/decadriver.ads
@@ -388,10 +388,10 @@ is
                                                 Load_Antenna_Delay,
                                                 Load_XTAL_Trim,
                                                 Load_UCode_From_ROM),
-                    Driver             => + (DW1000.BSP.Device_State,
-                                                  Load_Antenna_Delay,
-                                                  Load_XTAL_Trim,
-                                                  Load_UCode_From_ROM),
+                    Driver             =>+ (DW1000.BSP.Device_State,
+                                            Load_Antenna_Delay,
+                                            Load_XTAL_Trim,
+                                            Load_UCode_From_ROM),
                     null                    => Ada.Real_Time.Clock_Time);
       --  Initialize the DecaDriver and DW1000.
       --
@@ -418,21 +418,20 @@ is
         Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
                                                 Config,
                                                 Driver),
-                    Driver             => + Config);
+                    Driver             =>+ Config);
       --  Configure the DW1000 for a specific channel, PRF, preamble, etc...
 
-
-      procedure Configure_Errors (Frame_Timeout : in Boolean;
-                                  SFD_Timeout   : in Boolean;
-                                  PHR_Error     : in Boolean;
-                                  RS_Error      : in Boolean;
-                                  FCS_Error     : in Boolean)
+      procedure Configure_Errors (Enable_Frame_Timeout : in Boolean;
+                                  Enable_SFD_Timeout   : in Boolean;
+                                  Enable_PHR_Error     : in Boolean;
+                                  Enable_RS_Error      : in Boolean;
+                                  Enable_FCS_Error     : in Boolean)
         with Global => null,
-        Depends => (Driver =>+ (Frame_Timeout,
-                                SFD_Timeout,
-                                PHR_Error,
-                                RS_Error,
-                                FCS_Error));
+        Depends => (Driver =>+ (Enable_Frame_Timeout,
+                                Enable_SFD_Timeout,
+                                Enable_PHR_Error,
+                                Enable_RS_Error,
+                                Enable_FCS_Error));
       --  Configure which error notifications are enabled.
       --
       --  @param Frame_Timeout Set to True if error notifications should be
@@ -469,7 +468,7 @@ is
       function Get_Lot_ID  return Bits_32;
 
       function PHR_Mode return DW1000.Driver.Physical_Header_Modes
-        With Depends => (PHR_Mode'Result => Driver);
+        with Depends => (PHR_Mode'Result => Driver);
 
       procedure Start_Tx_Immediate (Rx_After_Tx     : in Boolean;
                                     Auto_Append_FCS : in Boolean)
@@ -493,7 +492,6 @@ is
       --  If Auto_Append_FCS is set to True then the DW1000 will automatically
       --  calculate and append the 2-byte frame check sequence (FCS) to the
       --  transmitted frame.
-
 
       procedure Start_Tx_Delayed
         (Rx_After_Tx : in     Boolean;
@@ -526,7 +524,7 @@ is
                      Frame_Info :    out Frame_Info_Type;
                      Status     :    out Rx_Status_Type;
                      Overrun    :    out Boolean)
-      with Depends => (Frame         => + Driver,
+      with Depends => (Frame         =>+ Driver,
                        Frame_Info    => Driver,
                        Length        => Driver,
                        Driver        => Driver,
@@ -616,14 +614,14 @@ is
 
       procedure Frame_Received
         with Global => (In_Out => DW1000.BSP.Device_State),
-        Depends => (DW1000.BSP.Device_State => + Driver,
-                    Driver                  => + DW1000.BSP.Device_State);
+        Depends => (DW1000.BSP.Device_State =>+ Driver,
+                    Driver                  =>+ DW1000.BSP.Device_State);
       --  Reads a received frame from the DW1000.
       --
 
-      procedure Receive_Error (Error : in Rx_Status_Type)
-        with Depends => (Driver => + Error),
-        Pre => Error /= No_Error;
+      procedure Receive_Error (Result : in Rx_Status_Type)
+        with Depends => (Driver =>+ Result),
+        Pre => Result /= No_Error;
 
       procedure DW1000_IRQ
         with Attach_Handler => DecaDriver_Config.DW1000_IRQ_Id,
@@ -687,7 +685,9 @@ is
                        Overrun    => False));
       --  Cyclic buffer for storing received frames, read from the DW1000.
 
-      Queue_Head       : Implementation.Rx_Frame_Queue_Index := Implementation.Rx_Frame_Queue_Index'Last;
+      Queue_Head       : Implementation.Rx_Frame_Queue_Index
+        := Implementation.Rx_Frame_Queue_Index'Last;
+
       Rx_Count         : Implementation.Rx_Frame_Queue_Count := 0;
       Overrun_Occurred : Boolean                             := False;
       Frame_Ready      : Boolean                             := False;

--- a/src/dw1000-bsp.ads
+++ b/src/dw1000-bsp.ads
@@ -74,7 +74,6 @@ is
      with Global => (In_Out => Device_State);
    --  Enables the DW1000 IRQ.
 
-
    procedure Use_Slow_SPI_Clock
      with Global => (In_Out => Device_State);
    --  Switch the BSP to use a slow SPI clock speed (no faster than 3 MHz).
@@ -82,14 +81,12 @@ is
    --  The slow SPI clock speed should be used when the DW1000 is in the INIT
    --  state.
 
-
    procedure Use_Fast_SPI_Clock
      with Global => (In_Out => Device_State);
    --  Switch the BSP to use a faster SPI clock speed (no faster than 20 MHz).
    --
    --  The fast SPI clock speed can be used when the DW1000 has left the INIT
    --  state.
-
 
    procedure Wakeup (Wait_For_INIT : in Boolean)
      with Global => (In_Out => Device_State);
@@ -105,11 +102,10 @@ is
    --  This is a non-blocking function (the Ada 'delay' statement is not used).
    --  Instead, a busy wait is be used for the delays.
 
-
-   procedure Write_Transaction(Header : in DW1000.Types.Byte_Array;
-                               Data   : in DW1000.Types.Byte_Array)
+   procedure Write_Transaction (Header : in DW1000.Types.Byte_Array;
+                                Data   : in DW1000.Types.Byte_Array)
      with Global => (In_Out => Device_State),
-     Depends => (Device_State => + (Header, Data)),
+     Depends => (Device_State =>+ (Header, Data)),
      Pre => (Header'Length in 1 .. 3
              and Data'Length > 0);
    --  Perform a "write" transaction to the DW1000.
@@ -126,10 +122,10 @@ is
    --  Note: This procedure must not block. I.e. the procedure must not use
    --  the 'delay until' statement, nor call any protected entries.
 
-   procedure Read_Transaction(Header : in     DW1000.Types.Byte_Array;
+   procedure Read_Transaction (Header : in     DW1000.Types.Byte_Array;
                               Data   :    out DW1000.Types.Byte_Array)
      with Global => (In_Out => Device_State),
-     Depends => (Device_State => + (Header, Data),
+     Depends => (Device_State =>+ (Header, Data),
                  Data         => (Header, Device_State)),
      Pre => (Header'Length in 1 .. 3
              and Data'Length > 0);

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -188,16 +188,15 @@ is
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       --  Kick off the NV MEM load
-      OTP_CTRL.Write (OTP_CTRL_Type'
-                        (OTPRDEN    => Disabled,
-                         OTPREAD    => No_Action,
-                         OTPMRWR    => Clear,
-                         OTPPROG    => Clear,
-                         OTPMR      => Clear,
-                         LDELOAD    => Load_LDE_Microcode,
-                         Reserved_1 => 0,
-                         Reserved_2 => 0,
-                         Reserved_3 => 0));
+      OTP_CTRL.Write ((OTPRDEN    => Disabled,
+                       OTPREAD    => No_Action,
+                       OTPMRWR    => Clear,
+                       OTPPROG    => Clear,
+                       OTPMR      => Clear,
+                       LDELOAD    => Load_LDE_Microcode,
+                       Reserved_1 => 0,
+                       Reserved_2 => 0,
+                       Reserved_3 => 0));
 
       --  Code upload takes up to 150 us
       --  A busy wait is used here to prevent blocking the calling task.
@@ -299,20 +298,18 @@ is
 
    begin
       --  Set OTP address to read
-      OTP_ADDR.Write (OTP_ADDR_Type'(OTP_ADDR => Address,
-                                     Reserved => 0));
+      OTP_ADDR.Write ((OTP_ADDR => Address, others => <>));
 
       --  Trigger OTP read
-      CTRL_Reg := OTP_CTRL_Type'
-        (OTPRDEN    => Enabled,
-         OTPREAD    => Trigger_Read,
-         OTPMRWR    => Clear,
-         OTPPROG    => Clear,
-         OTPMR      => Clear,
-         LDELOAD    => No_Action,
-         Reserved_1 => 0,
-         Reserved_2 => 0,
-         Reserved_3 => 0);
+      CTRL_Reg := (OTPRDEN    => Enabled,
+                   OTPREAD    => Trigger_Read,
+                   OTPMRWR    => Clear,
+                   OTPPROG    => Clear,
+                   OTPMR      => Clear,
+                   LDELOAD    => No_Action,
+                   Reserved_1 => 0,
+                   Reserved_2 => 0,
+                   Reserved_3 => 0);
 
       OTP_CTRL.Write (CTRL_Reg);
 
@@ -479,7 +476,7 @@ is
 
    begin
       LDE_CFG1.Write (LDE_CFG1_Value);
-      LDE_CFG2.Write (LDE_CFG2_Type'(LDE_CFG2 => LDE_CFG2_Values (PRF)));
+      LDE_CFG2.Write ((LDE_CFG2 => LDE_CFG2_Values (PRF)));
 
       REPC_Coeff := LDE_Replica_Coeffs (Rx_Preamble_Code);
 
@@ -901,19 +898,15 @@ is
 
    begin
       if Config.Smart_Tx_Power_Enabled then
-         TX_POWER.Write
-           (TX_POWER_Type'
-              (BOOSTNORM => Config.Boost_Normal,
-               BOOSTP500 => Config.Boost_500us,
-               BOOSTP250 => Config.Boost_250us,
-               BOOSTP125 => Config.Boost_125us));
+         TX_POWER.Write ((BOOSTNORM => Config.Boost_Normal,
+                          BOOSTP500 => Config.Boost_500us,
+                          BOOSTP250 => Config.Boost_250us,
+                          BOOSTP125 => Config.Boost_125us));
       else
-         TX_POWER.Write
-           (TX_POWER_Type'
-              (BOOSTNORM => Config.Boost_PHR,
-               BOOSTP500 => Config.Boost_PHR,
-               BOOSTP250 => Config.Boost_SHR,
-               BOOSTP125 => Config.Boost_SHR));
+         TX_POWER.Write ((BOOSTNORM => Config.Boost_PHR,
+                          BOOSTP500 => Config.Boost_PHR,
+                          BOOSTP250 => Config.Boost_SHR,
+                          BOOSTP125 => Config.Boost_SHR));
       end if;
 
       SYS_CFG.Read (SYS_CFG_Reg);
@@ -964,19 +957,20 @@ is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
 
    begin
-      SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => (if Auto_Append_FCS then Not_Suppressed else Suppressed),
-         TXSTRT     => Start_Tx,
-         TXDLYS     => Not_Delayed,
-         CANSFCS    => Not_Cancelled,
-         TRXOFF     => No_Action,
-         WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
-         RXENAB     => No_Action,
-         RXDLYE     => Not_Delayed,
-         HRBPT      => No_Action,
-         Reserved_1 => 0,
-         Reserved_2 => 0,
-         Reserved_3 => 0);
+      SYS_CTRL_Reg :=  (SFCST      => (if Auto_Append_FCS
+                                       then Not_Suppressed
+                                       else Suppressed),
+                        TXSTRT     => Start_Tx,
+                        TXDLYS     => Not_Delayed,
+                        CANSFCS    => Not_Cancelled,
+                        TRXOFF     => No_Action,
+                        WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
+                        RXENAB     => No_Action,
+                        RXDLYE     => Not_Delayed,
+                        HRBPT      => No_Action,
+                        Reserved_1 => 0,
+                        Reserved_2 => 0,
+                        Reserved_3 => 0);
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
    end Start_Tx_Immediate;
@@ -991,19 +985,18 @@ is
       SYS_STATUS_Reg : SYS_STATUS_Type;
 
    begin
-      SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => Not_Suppressed,
-         TXSTRT     => Start_Tx,
-         TXDLYS     => Delayed,
-         CANSFCS    => Not_Cancelled,
-         TRXOFF     => No_Action,
-         WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
-         RXENAB     => No_Action,
-         RXDLYE     => Not_Delayed,
-         HRBPT      => No_Action,
-         Reserved_1 => 0,
-         Reserved_2 => 0,
-         Reserved_3 => 0);
+      SYS_CTRL_Reg := (SFCST      => Not_Suppressed,
+                       TXSTRT     => Start_Tx,
+                       TXDLYS     => Delayed,
+                       CANSFCS    => Not_Cancelled,
+                       TRXOFF     => No_Action,
+                       WAIT4RESP  => (if Rx_After_Tx then Wait else No_Wait),
+                       RXENAB     => No_Action,
+                       RXDLYE     => Not_Delayed,
+                       HRBPT      => No_Action,
+                       Reserved_1 => 0,
+                       Reserved_2 => 0,
+                       Reserved_3 => 0);
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
 
@@ -1014,18 +1007,18 @@ is
 
       else
          --  Cancel the transmit
-         SYS_CTRL_Reg := SYS_CTRL_Type'(SFCST      => Not_Suppressed,
-                                        TXSTRT     => No_Action,
-                                        TXDLYS     => Not_Delayed,
-                                        CANSFCS    => Not_Cancelled,
-                                        TRXOFF     => Transceiver_Off,
-                                        WAIT4RESP  => No_Wait,
-                                        RXENAB     => No_Action,
-                                        RXDLYE     => Not_Delayed,
-                                        HRBPT      => No_Action,
-                                        Reserved_1 => 0,
-                                        Reserved_2 => 0,
-                                        Reserved_3 => 0);
+         SYS_CTRL_Reg := (SFCST      => Not_Suppressed,
+                          TXSTRT     => No_Action,
+                          TXDLYS     => Not_Delayed,
+                          CANSFCS    => Not_Cancelled,
+                          TRXOFF     => Transceiver_Off,
+                          WAIT4RESP  => No_Wait,
+                          RXENAB     => No_Action,
+                          RXDLYE     => Not_Delayed,
+                          HRBPT      => No_Action,
+                          Reserved_1 => 0,
+                          Reserved_2 => 0,
+                          Reserved_3 => 0);
          SYS_CTRL.Write (SYS_CTRL_Reg);
 
          Set_Sleep_After_Tx (Enable => False);
@@ -1054,7 +1047,7 @@ is
 
    procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time) is
    begin
-      DX_TIME.Write (DX_TIME_Type'(DX_TIME => Delay_Time));
+      DX_TIME.Write ((DX_TIME => Delay_Time));
    end Set_Delayed_Tx_Rx_Time;
 
    --------------------------
@@ -1180,35 +1173,34 @@ is
    begin
       --  Temporarily disable all interrupts
       SYS_MASK.Read (SYS_MASK_Reg);
-      SYS_MASK.Write (SYS_MASK_Type'(others => <>));
+      SYS_MASK.Write ((others => <>));
 
       --  Force transceiver off;
-      SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF => Transceiver_Off,
-                                     others => <>));
+      SYS_CTRL.Write ((TRXOFF => Transceiver_Off, others => <>));
 
       --  Clear any pending events.
-      SYS_STATUS.Write (SYS_STATUS_Type'(AAT        => 1,
-                                         TXFRB      => 1,
-                                         TXPRS      => 1,
-                                         TXPHS      => 1,
-                                         TXFRS      => 1,
-                                         RXPRD      => 1,
-                                         RXSFDD     => 1,
-                                         LDEDONE    => 1,
-                                         RXPHD      => 1,
-                                         RXPHE      => 1,
-                                         RXDFR      => 1,
-                                         RXFCG      => 1,
-                                         RXFCE      => 1,
-                                         RXRFSL     => 1,
-                                         RXRFTO     => 1,
-                                         LDEERR     => 1,
-                                         RXPTO      => 1,
-                                         RXSFDTO    => 1,
-                                         AFFREJ     => 1,
-                                         Reserved_1 => 0,
-                                         Reserved_2 => 0,
-                                         others     => 0));
+      SYS_STATUS.Write ((AAT        => 1,
+                         TXFRB      => 1,
+                         TXPRS      => 1,
+                         TXPHS      => 1,
+                         TXFRS      => 1,
+                         RXPRD      => 1,
+                         RXSFDD     => 1,
+                         LDEDONE    => 1,
+                         RXPHD      => 1,
+                         RXPHE      => 1,
+                         RXDFR      => 1,
+                         RXFCG      => 1,
+                         RXFCE      => 1,
+                         RXRFSL     => 1,
+                         RXRFTO     => 1,
+                         LDEERR     => 1,
+                         RXPTO      => 1,
+                         RXSFDTO    => 1,
+                         AFFREJ     => 1,
+                         Reserved_1 => 0,
+                         Reserved_2 => 0,
+                         others     => 0));
 
       Sync_Rx_Buffer_Pointers;
 
@@ -1278,19 +1270,18 @@ is
    begin
       Sync_Rx_Buffer_Pointers;
 
-      SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => Not_Suppressed,
-         TXSTRT     => No_Action,
-         TXDLYS     => Not_Delayed,
-         CANSFCS    => Not_Cancelled,
-         TRXOFF     => No_Action,
-         WAIT4RESP  => No_Wait,
-         RXENAB     => Start_Rx,
-         RXDLYE     => Not_Delayed,
-         HRBPT      => No_Action,
-         Reserved_1 => 0,
-         Reserved_2 => 0,
-         Reserved_3 => 0);
+      SYS_CTRL_Reg := (SFCST      => Not_Suppressed,
+                       TXSTRT     => No_Action,
+                       TXDLYS     => Not_Delayed,
+                       CANSFCS    => Not_Cancelled,
+                       TRXOFF     => No_Action,
+                       WAIT4RESP  => No_Wait,
+                       RXENAB     => Start_Rx,
+                       RXDLYE     => Not_Delayed,
+                       HRBPT      => No_Action,
+                       Reserved_1 => 0,
+                       Reserved_2 => 0,
+                       Reserved_3 => 0);
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
 
@@ -1307,19 +1298,18 @@ is
    begin
       Sync_Rx_Buffer_Pointers;
 
-      SYS_CTRL_Reg := SYS_CTRL_Type'
-        (SFCST      => Not_Suppressed,
-         TXSTRT     => No_Action,
-         TXDLYS     => Not_Delayed,
-         CANSFCS    => Not_Cancelled,
-         TRXOFF     => No_Action,
-         WAIT4RESP  => No_Wait,
-         RXENAB     => Start_Rx,
-         RXDLYE     => Delayed,
-         HRBPT      => No_Action,
-         Reserved_1 => 0,
-         Reserved_2 => 0,
-         Reserved_3 => 0);
+      SYS_CTRL_Reg := (SFCST      => Not_Suppressed,
+                       TXSTRT     => No_Action,
+                       TXDLYS     => Not_Delayed,
+                       CANSFCS    => Not_Cancelled,
+                       TRXOFF     => No_Action,
+                       WAIT4RESP  => No_Wait,
+                       RXENAB     => Start_Rx,
+                       RXDLYE     => Delayed,
+                       HRBPT      => No_Action,
+                       Reserved_1 => 0,
+                       Reserved_2 => 0,
+                       Reserved_3 => 0);
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
 
@@ -1350,18 +1340,14 @@ is
                           Rx_Off_Time : in Sniff_Off_Time) is
    begin
       if Mode = Normal then
-         RX_SNIFF.Write (RX_SNIFF_Type'(SNIFF_ONT  => 0,
-                                        SNIFF_OFFT => 0.0,
-                                        Reserved_1 => 0,
-                                        Reserved_2 => 0));
+         RX_SNIFF.Write ((SNIFF_ONT  => 0,
+                          SNIFF_OFFT => 0.0,
+                          others     => <>));
 
       else
-         RX_SNIFF.Write
-           (RX_SNIFF_Type'
-              (SNIFF_ONT  => Rx_On_Time,
-               SNIFF_OFFT => Rx_Off_Time,
-               Reserved_1 => 0,
-               Reserved_2 => 0));
+         RX_SNIFF.Write ((SNIFF_ONT  => Rx_On_Time,
+                          SNIFF_OFFT => Rx_Off_Time,
+                          others     => <>));
       end if;
 
    end Set_Rx_Mode;
@@ -1436,17 +1422,17 @@ is
 
    begin
       --  Enable calibration
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
-                                     SMXX     => Clear,
-                                     LPOSC_C  => Enabled,
-                                     Reserved => 0));
+      AON_CFG1.Write ((SLEEP_CE => Disabled,
+                       SMXX     => Clear,
+                       LPOSC_C  => Enabled,
+                       Reserved => 0));
       Upload_AON_Config;
 
       --  Disable calibration
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
-                                     SMXX     => Clear,
-                                     LPOSC_C  => Disabled,
-                                     Reserved => 0));
+      AON_CFG1.Write ((SLEEP_CE => Disabled,
+                       SMXX     => Clear,
+                       LPOSC_C  => Disabled,
+                       Reserved => 0));
       Upload_AON_Config;
 
       PMSC_CTRL0.Read (PMSC_CTRL0_Reg);
@@ -1474,18 +1460,18 @@ is
 
    procedure Upload_AON_Config is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => Upload,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => Upload,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end Upload_AON_Config;
 
    -----------------------------
@@ -1494,12 +1480,12 @@ is
 
    procedure Save_Registers_To_AON is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => Save,      --  This bit auto-clears
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => Save,      --  This bit auto-clears
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end Save_Registers_To_AON;
 
    ----------------------------------
@@ -1508,12 +1494,12 @@ is
 
    procedure Restore_Registers_From_AON is
    begin
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => Restore,   --  This bit auto-clears
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => Restore,   --  This bit auto-clears
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end Restore_Registers_From_AON;
 
    ---------------------
@@ -1526,35 +1512,35 @@ is
 
    begin
       --  Load address
-      AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
+      AON_ADDR.Write ((AON_ADDR => Address));
 
       --  Enable DCA_ENAB
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Enabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Enabled,
+                       Reserved => 0));
 
       --  Now also enable DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => Trigger_Read,
-                                     DCA_ENAB => Enabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => Trigger_Read,
+                       DCA_ENAB => Enabled,
+                       Reserved => 0));
 
       --  Read the result
       AON_RDAT.Read (AON_RDAT_Reg);
       Data := AON_RDAT_Reg.AON_RDAT;
 
       --  Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end AON_Read_Byte;
 
    ---------------------------
@@ -1569,23 +1555,23 @@ is
    begin
       for I in Data'Range loop
          --  Load address
-         AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
+         AON_ADDR.Write ((AON_ADDR => Address));
 
          --  Enable DCA_ENAB
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                        SAVE     => No_Action,
-                                        UPL_CFG  => No_Action,
-                                        DCA_READ => No_Action,
-                                        DCA_ENAB => Enabled,
-                                        Reserved => 0));
+         AON_CTRL.Write ((RESTORE  => No_Action,
+                          SAVE     => No_Action,
+                          UPL_CFG  => No_Action,
+                          DCA_READ => No_Action,
+                          DCA_ENAB => Enabled,
+                          Reserved => 0));
 
          --  Now also enable DCA_READ
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                        SAVE     => No_Action,
-                                        UPL_CFG  => No_Action,
-                                        DCA_READ => Trigger_Read,
-                                        DCA_ENAB => Enabled,
-                                        Reserved => 0));
+         AON_CTRL.Write ((RESTORE  => No_Action,
+                          SAVE     => No_Action,
+                          UPL_CFG  => No_Action,
+                          DCA_READ => Trigger_Read,
+                          DCA_ENAB => Enabled,
+                          Reserved => 0));
 
          --  Read the result
          AON_RDAT.Read (AON_RDAT_Reg);
@@ -1595,12 +1581,12 @@ is
       end loop;
 
       --  Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end AON_Contiguous_Read;
 
    ------------------------
@@ -1619,23 +1605,23 @@ is
 
       for I in 0 .. Data'Length - 1 loop
          --  Load address
-         AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Addresses (A_First + I)));
+         AON_ADDR.Write ((AON_ADDR => Addresses (A_First + I)));
 
          --  Enable DCA_ENAB
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                        SAVE     => No_Action,
-                                        UPL_CFG  => No_Action,
-                                        DCA_READ => No_Action,
-                                        DCA_ENAB => Enabled,
-                                        Reserved => 0));
+         AON_CTRL.Write ((RESTORE  => No_Action,
+                          SAVE     => No_Action,
+                          UPL_CFG  => No_Action,
+                          DCA_READ => No_Action,
+                          DCA_ENAB => Enabled,
+                          Reserved => 0));
 
          --  Now also enable DCA_READ
-         AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                        SAVE     => No_Action,
-                                        UPL_CFG  => No_Action,
-                                        DCA_READ => Trigger_Read,
-                                        DCA_ENAB => Enabled,
-                                        Reserved => 0));
+         AON_CTRL.Write ((RESTORE  => No_Action,
+                          SAVE     => No_Action,
+                          UPL_CFG  => No_Action,
+                          DCA_READ => Trigger_Read,
+                          DCA_ENAB => Enabled,
+                          Reserved => 0));
 
          --  Read the result
          AON_RDAT.Read (AON_RDAT_Reg);
@@ -1643,12 +1629,12 @@ is
       end loop;
 
       --  Clear DCA_ENAB and DCA_READ
-      AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
-                                     SAVE     => No_Action,
-                                     UPL_CFG  => No_Action,
-                                     DCA_READ => No_Action,
-                                     DCA_ENAB => Disabled,
-                                     Reserved => 0));
+      AON_CTRL.Write ((RESTORE  => No_Action,
+                       SAVE     => No_Action,
+                       UPL_CFG  => No_Action,
+                       DCA_READ => No_Action,
+                       DCA_ENAB => Disabled,
+                       Reserved => 0));
    end AON_Scatter_Read;
 
    -----------------------------
@@ -1665,37 +1651,37 @@ is
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
       --  Make sure we don't accidentally sleep
-      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
-                                     WAKE_PIN  => Disabled,
-                                     WAKE_SPI  => Disabled,
-                                     WAKE_CNT  => Disabled,
-                                     LPDIV_EN  => Disabled,
-                                     LPCLKDIVA => <>,
-                                     SLEEP_TIM => <>));
+      AON_CFG0.Write ((SLEEP_EN  => Disabled,
+                       WAKE_PIN  => Disabled,
+                       WAKE_SPI  => Disabled,
+                       WAKE_CNT  => Disabled,
+                       LPDIV_EN  => Disabled,
+                       LPCLKDIVA => <>,
+                       SLEEP_TIM => <>));
 
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
-                                     SMXX     => Clear,
-                                     LPOSC_C  => Disabled,
-                                     Reserved => 0));
+      AON_CFG1.Write ((SLEEP_CE => Disabled,
+                       SMXX     => Clear,
+                       LPOSC_C  => Disabled,
+                       Reserved => 0));
 
       --  Disable the sleep counter
       Upload_AON_Config;
 
       --  Set the new value
-      AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
-                                     WAKE_PIN  => Disabled,
-                                     WAKE_SPI  => Disabled,
-                                     WAKE_CNT  => Disabled,
-                                     LPDIV_EN  => Disabled,
-                                     LPCLKDIVA => <>,
-                                     SLEEP_TIM => Sleep_Count));
+      AON_CFG0.Write ((SLEEP_EN  => Disabled,
+                       WAKE_PIN  => Disabled,
+                       WAKE_SPI  => Disabled,
+                       WAKE_CNT  => Disabled,
+                       LPDIV_EN  => Disabled,
+                       LPCLKDIVA => <>,
+                       SLEEP_TIM => Sleep_Count));
       Upload_AON_Config;
 
       --  Enable the new value
-      AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Enabled,
-                                     SMXX     => Clear,
-                                     LPOSC_C  => Disabled,
-                                     Reserved => 0));
+      AON_CFG1.Write ((SLEEP_CE => Enabled,
+                       SMXX     => Clear,
+                       LPOSC_C  => Disabled,
+                       Reserved => 0));
 
       PMSC_CTRL0_Reg.SYSCLKS := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -166,8 +166,7 @@ is
    --  Load_LDE_From_ROM  --
    -------------------------
 
-   procedure Load_LDE_From_ROM
-   is
+   procedure Load_LDE_From_ROM is
       use type Ada.Real_Time.Time;
 
       Finish_Time : Ada.Real_Time.Time;
@@ -229,8 +228,7 @@ is
    --  Enable_Clocks  --
    ---------------------
 
-   procedure Enable_Clocks (Clock : in Clocks)
-   is
+   procedure Enable_Clocks (Clock : in Clocks) is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
 
    begin
@@ -295,8 +293,7 @@ is
    ----------------
 
    procedure Read_OTP (Address : in     OTP_ADDR_Field;
-                       Word    :    out Bits_32)
-   is
+                       Word    :    out Bits_32) is
       CTRL_Reg : OTP_CTRL_Type;
       RDAT_Reg : OTP_RDAT_Type;
 
@@ -334,8 +331,7 @@ is
    --  Read_EUID  --
    -----------------
 
-   procedure Read_EUID (EUID : out Bits_64)
-   is
+   procedure Read_EUID (EUID : out Bits_64) is
       EUI_Reg : EUI_Type;
 
    begin
@@ -348,8 +344,7 @@ is
    --  Write_EUID  --
    ------------------
 
-   procedure Write_EUID (EUID : in Bits_64)
-   is
+   procedure Write_EUID (EUID : in Bits_64) is
    begin
       EUI.Write ((EUI => EUID));
    end Write_EUID;
@@ -358,8 +353,7 @@ is
    --  Read_PAN_ID  --
    -------------------
 
-   procedure Read_PAN_ID (PAN_ID : out Bits_16)
-   is
+   procedure Read_PAN_ID (PAN_ID : out Bits_16) is
       PANADR_Reg : PANADR_Type;
 
    begin
@@ -371,8 +365,7 @@ is
    --  Write_PAN_ID  --
    --------------------
 
-   procedure Write_PAN_ID (PAN_ID : in Bits_16)
-   is
+   procedure Write_PAN_ID (PAN_ID : in Bits_16) is
       PANADR_Reg : PANADR_Type;
 
    begin
@@ -385,8 +378,7 @@ is
    --  Read_Short_Address  --
    --------------------------
 
-   procedure Read_Short_Address (Short_Address : out Bits_16)
-   is
+   procedure Read_Short_Address (Short_Address : out Bits_16) is
       PANADR_Reg : PANADR_Type;
 
    begin
@@ -398,8 +390,7 @@ is
    --  Write_Short_Address  --
    ---------------------------
 
-   procedure Write_Short_Address (Short_Address : in Bits_16)
-   is
+   procedure Write_Short_Address (Short_Address : in Bits_16) is
       PANADR_Reg : PANADR_Type;
 
    begin
@@ -413,8 +404,7 @@ is
    -------------------------------------
 
    procedure Read_PAN_ID_And_Short_Address (PAN_ID        : out Bits_16;
-                                            Short_Address : out Bits_16)
-   is
+                                            Short_Address : out Bits_16) is
       PANADR_Reg : PANADR_Type;
 
    begin
@@ -428,8 +418,7 @@ is
    --------------------------------------
 
    procedure Write_PAN_ID_And_Short_Address (PAN_ID        : in Bits_16;
-                                             Short_Address : in Bits_16)
-   is
+                                             Short_Address : in Bits_16) is
    begin
       PANADR.Write ((PAN_ID     => PAN_ID,
                      SHORT_ADDR => Short_Address));
@@ -439,8 +428,7 @@ is
    --  Read_Tx_Antenna_Delay  --
    -----------------------------
 
-   procedure Read_Tx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time)
-   is
+   procedure Read_Tx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time) is
       TX_ANTD_Reg : TX_ANTD_Type;
 
    begin
@@ -453,8 +441,7 @@ is
    --  Write_Tx_Antenna_Delay  --
    ------------------------------
 
-   procedure Write_Tx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
-   is
+   procedure Write_Tx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time) is
    begin
       TX_ANTD.Write ((TX_ANTD => Antenna_Delay));
    end Write_Tx_Antenna_Delay;
@@ -463,8 +450,7 @@ is
    --  Read_Rx_Antenna_Delay  --
    -----------------------------
 
-   procedure Read_Rx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time)
-   is
+   procedure Read_Rx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time) is
       LDE_RXANTD_Reg : LDE_RXANTD_Type;
 
    begin
@@ -477,8 +463,7 @@ is
    --  Write_Rx_Antenna_Delay  --
    ------------------------------
 
-   procedure Write_Rx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
-   is
+   procedure Write_Rx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time) is
    begin
       LDE_RXANTD.Write ((LDE_RXANTD => Antenna_Delay));
    end Write_Rx_Antenna_Delay;
@@ -489,8 +474,7 @@ is
 
    procedure Configure_LDE (PRF              : in PRF_Type;
                             Rx_Preamble_Code : in Preamble_Code_Number;
-                            Data_Rate        : in Data_Rates)
-   is
+                            Data_Rate        : in Data_Rates) is
       REPC_Coeff : LDE_REPC_Field;
 
    begin
@@ -513,8 +497,7 @@ is
    --  Configure_PLL  --
    ---------------------
 
-   procedure Configure_PLL (Channel : in Channel_Number)
-   is
+   procedure Configure_PLL (Channel : in Channel_Number) is
    begin
       FS_PLLCFG.Write  ((FS_PLLCFG  => FS_PLLCFG_Values  (Positive (Channel))));
       FS_PLLTUNE.Write ((FS_PLLTUNE => FS_PLLTUNE_Values (Positive (Channel))));
@@ -525,8 +508,7 @@ is
    --  Configure_RF  --
    --------------------
 
-   procedure Configure_RF (Channel : in Channel_Number)
-   is
+   procedure Configure_RF (Channel : in Channel_Number) is
    begin
       RF_RXCTRLH.Write ((RF_RXCTRLH => RF_RXCTRLH_Values (Positive (Channel))));
       RF_TXCTRL.Write  ((RF_TXCTRL  => RF_TXCTRL_Values (Positive (Channel))));
@@ -542,8 +524,7 @@ is
                             Tx_Preamble_Length : in Preamble_Lengths;
                             PAC                : in Preamble_Acq_Chunk_Length;
                             SFD_Timeout        : in SFD_Timeout_Number;
-                            Nonstandard_SFD    : in Boolean)
-   is
+                            Nonstandard_SFD    : in Boolean) is
    begin
       DRX_TUNE0b.Write ((DRX_TUNE0b => DRX_TUNE0b_Values (Data_Rate,
                                                           Nonstandard_SFD)));
@@ -568,8 +549,7 @@ is
    --  Configure_AGC  --
    ---------------------
 
-   procedure Configure_AGC (PRF : in PRF_Type)
-   is
+   procedure Configure_AGC (PRF : in PRF_Type) is
    begin
 
       AGC_TUNE2.Write ((AGC_TUNE2 => AGC_TUNE2_Value));
@@ -582,8 +562,7 @@ is
    --  Configure_TC  --
    --------------------
 
-   procedure Configure_TC (Channel : in Channel_Number)
-   is
+   procedure Configure_TC (Channel : in Channel_Number) is
    begin
       TC_PGDELAY.Write
         ((TC_PGDELAY => TC_PGDELAY_Values (Positive (Channel))));
@@ -599,8 +578,7 @@ is
                                  Ranging             : in Boolean;
                                  Preamble_Length     : in Preamble_Lengths;
                                  Tx_Buffer_Offset    : in Natural;
-                                 Inter_Frame_Spacing : in Natural)
-   is
+                                 Inter_Frame_Spacing : in Natural) is
    begin
       TX_FCTRL.Write
         ((TFLEN    => TX_FCTRL_TFLEN_Field (Frame_Length mod 128),
@@ -640,8 +618,7 @@ is
       Use_Rx_User_Defined_SFD : in Boolean;
       Rx_PRF                  : in PRF_Type;
       Tx_Preamble_Code        : in Preamble_Code_Number;
-      Rx_Preamble_Code        : in Preamble_Code_Number)
-   is
+      Rx_Preamble_Code        : in Preamble_Code_Number) is
    begin
       CHAN_CTRL.Write ((TX_CHAN  => CHAN_CTRL_Channel_Field (Tx_Channel),
                         RX_CHAN  => CHAN_CTRL_Channel_Field (Rx_Channel),
@@ -665,8 +642,7 @@ is
    --  Configure_Nonstandard_SFD_Length  --
    ----------------------------------------
 
-   procedure Configure_Nonstandard_SFD_Length (Data_Rate : in Data_Rates)
-   is
+   procedure Configure_Nonstandard_SFD_Length (Data_Rate : in Data_Rates) is
       USR_SFD_Reg : Register_Types.USR_SFD_Type;
 
    begin
@@ -680,8 +656,7 @@ is
    ----------------------------------
 
    procedure Configure_Non_Standard_SFD (Rx_SFD : in String;
-                                         Tx_SFD : in String)
-   is
+                                         Tx_SFD : in String) is
 
       --  Takes a string of up to 8 SFD symbols and compute the value of one
       --  of the USR_SFD register's magnitude sub-registers (8 bits).
@@ -802,8 +777,7 @@ is
    --  Set_Frame_Filtering_Enabled  --
    -----------------------------------
 
-   procedure Set_Frame_Filtering_Enabled (Enable : in Boolean)
-   is
+   procedure Set_Frame_Filtering_Enabled (Enable : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
@@ -815,8 +789,7 @@ is
    --  Set_FCS_Check_Enabled  --
    -----------------------------
 
-   procedure Set_FCS_Check_Enabled (Enable : in Boolean)
-   is
+   procedure Set_FCS_Check_Enabled (Enable : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
@@ -835,8 +808,7 @@ is
                                         Allow_MAC_Cmd_Frame     : in Boolean;
                                         Allow_Reserved_Frame    : in Boolean;
                                         Allow_Frame_Type_4      : in Boolean;
-                                        Allow_Frame_Type_5      : in Boolean)
-   is
+                                        Allow_Frame_Type_5      : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
@@ -855,8 +827,7 @@ is
    --  Set_Smart_Tx_Power  --
    --------------------------
 
-   procedure Set_Smart_Tx_Power (Enable : in Boolean)
-   is
+   procedure Set_Smart_Tx_Power (Enable : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
@@ -871,8 +842,7 @@ is
 
    procedure Read_OTP_Tx_Power_Level (Channel     : in     Channel_Number;
                                       PRF         : in     PRF_Type;
-                                      Power_Level :    out TX_POWER_Type)
-   is
+                                      Power_Level :    out TX_POWER_Type) is
       Address : OTP_ADDR_Field;
       Word    : Bits_32;
 
@@ -906,8 +876,7 @@ is
 
    procedure Read_OTP_Antenna_Delay
      (Antenna_Delay_16_MHz : out Antenna_Delay_Time;
-      Antenna_Delay_64_MHz : out Antenna_Delay_Time)
-   is
+      Antenna_Delay_64_MHz : out Antenna_Delay_Time) is
       Word : Bits_32;
       Lo   : Bits_16;
       Hi   : Bits_16;
@@ -927,8 +896,7 @@ is
    --  Configure_Tx_Power  --
    --------------------------
 
-   procedure Configure_Tx_Power (Config : Tx_Power_Config_Type)
-   is
+   procedure Configure_Tx_Power (Config : Tx_Power_Config_Type) is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
@@ -960,8 +928,7 @@ is
    -------------------
 
    procedure Set_Tx_Data (Data   : in Types.Byte_Array;
-                          Offset : in Natural)
-   is
+                          Offset : in Natural) is
    begin
       if Data'Length > 0 then
          DW1000.Register_Driver.Write_Register
@@ -976,8 +943,7 @@ is
    ---------------------------
 
    procedure Set_Tx_Frame_Length (Length : in Natural;
-                                  Offset : in Natural)
-   is
+                                  Offset : in Natural) is
       TX_FCTRL_Reg : TX_FCTRL_Type;
 
    begin
@@ -994,8 +960,7 @@ is
    --------------------------
 
    procedure Start_Tx_Immediate (Rx_After_Tx     : in Boolean;
-                                 Auto_Append_FCS : in Boolean)
-   is
+                                 Auto_Append_FCS : in Boolean) is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
 
    begin
@@ -1021,8 +986,7 @@ is
    ------------------------
 
    procedure Start_Tx_Delayed (Rx_After_Tx : in     Boolean;
-                               Result      :    out Result_Type)
-   is
+                               Result      :    out Result_Type) is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
       SYS_STATUS_Reg : SYS_STATUS_Type;
 
@@ -1076,8 +1040,7 @@ is
    --------------------
 
    procedure Read_Rx_Data (Data   :    out Types.Byte_Array;
-                           Offset : in     Natural)
-   is
+                           Offset : in     Natural) is
    begin
       DW1000.Register_Driver.Read_Register
         (Register_ID => Registers.RX_BUFFER_Reg_ID,
@@ -1089,8 +1052,7 @@ is
    --  Set_Delayed_Tx_Rx_Time  --
    ------------------------------
 
-   procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time)
-   is
+   procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time) is
    begin
       DX_TIME.Write (DX_TIME_Type'(DX_TIME => Delay_Time));
    end Set_Delayed_Tx_Rx_Time;
@@ -1099,8 +1061,7 @@ is
    --  Set_Sleep_After_Tx  --
    --------------------------
 
-   procedure Set_Sleep_After_Tx (Enable : in Boolean)
-   is
+   procedure Set_Sleep_After_Tx (Enable : in Boolean) is
       PMSC_CTRL1_Reg : PMSC_CTRL1_Type;
 
    begin
@@ -1113,8 +1074,7 @@ is
    --  Read_Rx_Adjusted_Timestamp  --
    ----------------------------------
 
-   procedure Read_Rx_Adjusted_Timestamp (Timestamp : out Fine_System_Time)
-   is
+   procedure Read_Rx_Adjusted_Timestamp (Timestamp : out Fine_System_Time) is
       RX_TIME_Reg : RX_TIME_Type;
 
    begin
@@ -1126,8 +1086,7 @@ is
    --  Read_Rx_Raw_Timestamp  --
    -----------------------------
 
-   procedure Read_Rx_Raw_Timestamp (Timestamp : out Coarse_System_Time)
-   is
+   procedure Read_Rx_Raw_Timestamp (Timestamp : out Coarse_System_Time) is
       RX_TIME_Reg : RX_TIME_Type;
 
    begin
@@ -1140,8 +1099,7 @@ is
    --------------------------
 
    procedure Read_Rx_Timestamps (Adjusted : out Fine_System_Time;
-                                 Raw      : out Coarse_System_Time)
-   is
+                                 Raw      : out Coarse_System_Time) is
       RX_TIME_Reg : RX_TIME_Type;
 
    begin
@@ -1154,8 +1112,7 @@ is
    --  Read_Tx_Adjusted_Timestamp  --
    ----------------------------------
 
-   procedure Read_Tx_Adjusted_Timestamp (Timestamp : out Fine_System_Time)
-   is
+   procedure Read_Tx_Adjusted_Timestamp (Timestamp : out Fine_System_Time) is
       TX_TIME_Reg : TX_TIME_Type;
 
    begin
@@ -1167,8 +1124,7 @@ is
    --  Read_Tx_Raw_Timestamp  --
    -----------------------------
 
-   procedure Read_Tx_Raw_Timestamp (Timestamp : out Coarse_System_Time)
-   is
+   procedure Read_Tx_Raw_Timestamp (Timestamp : out Coarse_System_Time) is
       TX_TIME_Reg : TX_TIME_Type;
 
    begin
@@ -1181,8 +1137,7 @@ is
    --------------------------
 
    procedure Read_Tx_Timestamps (Adjusted : out Fine_System_Time;
-                                 Raw      : out Coarse_System_Time)
-   is
+                                 Raw      : out Coarse_System_Time) is
       TX_TIME_Reg : TX_TIME_Type;
 
    begin
@@ -1195,8 +1150,7 @@ is
    --  Read_System_Timestamp  --
    -----------------------------
 
-   procedure Read_System_Timestamp (Timestamp : out Coarse_System_Time)
-   is
+   procedure Read_System_Timestamp (Timestamp : out Coarse_System_Time) is
       SYS_TIME_Reg : SYS_TIME_Type;
 
    begin
@@ -1208,8 +1162,7 @@ is
    --  Check_Overrun  --
    ---------------------
 
-   procedure Check_Overrun (Overrun : out Boolean)
-   is
+   procedure Check_Overrun (Overrun : out Boolean) is
       SYS_STATUS_Reg : SYS_STATUS_Type;
 
    begin
@@ -1221,8 +1174,7 @@ is
    --  Force_Tx_Rx_Off  --
    -----------------------
 
-   procedure Force_Tx_Rx_Off
-   is
+   procedure Force_Tx_Rx_Off is
       SYS_MASK_Reg : SYS_MASK_Type;
 
    begin
@@ -1269,8 +1221,7 @@ is
    --  Reset_Rx  --
    ----------------
 
-   procedure Reset_Rx
-   is
+   procedure Reset_Rx is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
 
    begin
@@ -1291,8 +1242,7 @@ is
    --  Toggle_Host_Side_Rx_Buffer_Pointer  --
    ------------------------------------------
 
-   procedure Toggle_Host_Side_Rx_Buffer_Pointer
-   is
+   procedure Toggle_Host_Side_Rx_Buffer_Pointer is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
    begin
       SYS_CTRL.Read (SYS_CTRL_Reg);
@@ -1304,8 +1254,7 @@ is
    --  Sync_Rx_Buffer_Pointers  --
    -------------------------------
 
-   procedure Sync_Rx_Buffer_Pointers
-   is
+   procedure Sync_Rx_Buffer_Pointers is
       SYS_STATUS_Reg : SYS_STATUS_Type;
 
    begin
@@ -1323,8 +1272,7 @@ is
    --  Start_Rx_Immediate  --
    --------------------------
 
-   procedure Start_Rx_Immediate
-   is
+   procedure Start_Rx_Immediate is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
 
    begin
@@ -1352,8 +1300,7 @@ is
    --  Start_Rx_Delayed  --
    ------------------------
 
-   procedure Start_Rx_Delayed (Result  : out Result_Type)
-   is
+   procedure Start_Rx_Delayed (Result  : out Result_Type) is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
       SYS_STATUS_Reg : SYS_STATUS_Type;
 
@@ -1400,8 +1347,7 @@ is
 
    procedure Set_Rx_Mode (Mode        : in Rx_Modes;
                           Rx_On_Time  : in RX_SNIFF_SNIFF_ONT_Field;
-                          Rx_Off_Time : in Sniff_Off_Time)
-   is
+                          Rx_Off_Time : in Sniff_Off_Time) is
    begin
       if Mode = Normal then
          RX_SNIFF.Write (RX_SNIFF_Type'(SNIFF_ONT  => 0,
@@ -1424,8 +1370,7 @@ is
    --  Set_Auto_Rx_Reenable  --
    ----------------------------
 
-   procedure Set_Auto_Rx_Reenable (Enable : in Boolean)
-   is
+   procedure Set_Auto_Rx_Reenable (Enable : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
@@ -1438,8 +1383,7 @@ is
    --  Set_Rx_Double_Buffer  --
    ----------------------------
 
-   procedure Set_Rx_Double_Buffer (Enable : in Boolean)
-   is
+   procedure Set_Rx_Double_Buffer (Enable : in Boolean) is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
@@ -1452,8 +1396,7 @@ is
    --  Set_Rx_Frame_Wait_Timeout  --
    ---------------------------------
 
-   procedure Set_Rx_Frame_Wait_Timeout (Timeout : in Frame_Wait_Timeout_Time)
-   is
+   procedure Set_Rx_Frame_Wait_Timeout (Timeout : in Frame_Wait_Timeout_Time) is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
@@ -1476,8 +1419,7 @@ is
    --  Set_Preamble_Detect_Timeout  --
    -----------------------------------
 
-   procedure Set_Preamble_Detect_Timeout (Timeout : in DRX_PRETOC_Field)
-   is
+   procedure Set_Preamble_Detect_Timeout (Timeout : in DRX_PRETOC_Field) is
    begin
       DRX_PRETOC.Write ((DRX_PRETOC => Timeout));
    end Set_Preamble_Detect_Timeout;
@@ -1487,8 +1429,7 @@ is
    -----------------------------
 
    procedure Calibrate_Sleep_Count
-     (Half_XTAL_Cycles_Per_LP_Osc_Cycle : out Types.Bits_16)
-   is
+     (Half_XTAL_Cycles_Per_LP_Osc_Cycle : out Types.Bits_16) is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
 
       Data : Types.Byte_Array (1 .. 2);
@@ -1531,8 +1472,7 @@ is
    --  Upload_AON_Config  --
    -------------------------
 
-   procedure Upload_AON_Config
-   is
+   procedure Upload_AON_Config is
    begin
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
@@ -1552,8 +1492,7 @@ is
    --  Save_Registers_To_AON  --
    -----------------------------
 
-   procedure Save_Registers_To_AON
-   is
+   procedure Save_Registers_To_AON is
    begin
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => Save,      --  This bit auto-clears
@@ -1567,8 +1506,7 @@ is
    --  Restore_Registers_From_AON  --
    ----------------------------------
 
-   procedure Restore_Registers_From_AON
-   is
+   procedure Restore_Registers_From_AON is
    begin
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => Restore,   --  This bit auto-clears
                                      SAVE     => No_Action,
@@ -1583,8 +1521,7 @@ is
    ---------------------
 
    procedure AON_Read_Byte (Address : in     AON_ADDR_Field;
-                            Data    :    out Types.Bits_8)
-   is
+                            Data    :    out Types.Bits_8) is
       AON_RDAT_Reg : AON_RDAT_Type;
 
    begin
@@ -1625,8 +1562,7 @@ is
    ---------------------------
 
    procedure AON_Contiguous_Read (Start_Address : in     AON_ADDR_Field;
-                                  Data          :    out Types.Byte_Array)
-   is
+                                  Data          :    out Types.Byte_Array) is
       Address      : AON_ADDR_Field := Start_Address;
       AON_RDAT_Reg : AON_RDAT_Type;
 
@@ -1672,8 +1608,7 @@ is
    ------------------------
 
    procedure AON_Scatter_Read (Addresses : in     AON_Address_Array;
-                               Data      :    out Types.Byte_Array)
-   is
+                               Data      :    out Types.Byte_Array) is
       AON_RDAT_Reg : AON_RDAT_Type;
 
       A_First : constant Integer := Addresses'First;
@@ -1720,8 +1655,7 @@ is
    --  Configure_Sleep_Count  --
    -----------------------------
 
-   procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field)
-   is
+   procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field) is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
 
    begin
@@ -1772,8 +1706,7 @@ is
    --  Set_XTAL_Trim  --
    ---------------------
 
-   procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field)
-   is
+   procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field) is
       FS_XTALT_Reg : FS_XTALT_Type;
 
    begin
@@ -1790,8 +1723,7 @@ is
                              Rx_LED_Enable    : in Boolean;
                              Rx_OK_LED_Enable : in Boolean;
                              SFD_LED_Enable   : in Boolean;
-                             Test_Flash       : in Boolean)
-   is
+                             Test_Flash       : in Boolean) is
       GPIO_MODE_Reg  : Register_Types.GPIO_MODE_Type;
       PMSC_LEDC_Reg  : Register_Types.PMSC_LEDC_Type;
       PMSC_CTRL0_Reg : Register_Types.PMSC_CTRL0_Type;

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -671,8 +671,7 @@ is
       --  Magnitude  --
       -----------------
 
-      function Magnitude (SFD : in String) return Types.Bits_8
-      is
+      function Magnitude (SFD : in String) return Types.Bits_8 is
          Result : Bits_8 := 0;
 
       begin
@@ -689,8 +688,7 @@ is
       --  Polarity  --
       ----------------
 
-      function Polarity (SFD : in String) return Types.Bits_8
-      is
+      function Polarity (SFD : in String) return Types.Bits_8 is
          Result : Bits_8 := 0;
 
       begin

--- a/src/dw1000-driver.adb
+++ b/src/dw1000-driver.adb
@@ -24,19 +24,17 @@ with Ada.Unchecked_Conversion;
 with DW1000.Constants;       use DW1000.Constants;
 with DW1000.Registers;       use DW1000.Registers;
 with DW1000.Register_Driver;
-with DW1000.Register_Types;  use DW1000.Register_Types;
-
 
 package body DW1000.Driver
 with SPARK_Mode => On
 is
 
-   -- These values for LDE_CFG1 are given by the user manual
+   --  These values for LDE_CFG1 are given by the user manual
    LDE_CFG1_Value  : constant LDE_CFG1_Type
      := (NTM   => 13,
          PMULT => 3);
 
-   -- These values for LDE_CFG2 are given by the user manual
+   --  These values for LDE_CFG2 are given by the user manual
    LDE_CFG2_Values : constant array (PRF_Type) of LDE_CFG2_Field
      := (PRF_16MHz => LDE_CFG2_16MHz,
          PRF_64MHz => LDE_CFG2_64MHz);
@@ -68,7 +66,7 @@ is
            23 => LDE_REPC_Field (0.19 * 2**16),
            24 => LDE_REPC_Field (0.22 * 2**16));
 
-   -- These values for FS_PLLCFG are given by the user manual
+   --  These values for FS_PLLCFG are given by the user manual
    FS_PLLCFG_Values : constant array (Positive range 1 .. 7) of FS_PLLCFG_Field
      := (1 => FS_PLLCFG_Channel_1,
          2 => FS_PLLCFG_Channel_2,
@@ -76,11 +74,11 @@ is
          4 => FS_PLLCFG_Channel_4,
          5 => FS_PLLCFG_Channel_5,
          7 => FS_PLLCFG_Channel_7,
-         -- Note that channel 6 is not a valid channel. However, Channel_Number
-         -- cannot be used as the array index type since it has a predicate.
+         --  Note that channel 6 is not a valid channel. However, Channel_Number
+         --  cannot be used as the array index type since it has a predicate.
          6 => 0);
 
-   -- These values for FS_PLLTUNE are given by the user manual
+   --  These values for FS_PLLTUNE are given by the user manual
    FS_PLLTUNE_Values : constant array (Positive range 1 .. 7) of FS_PLLTUNE_Field
      := (1 => FS_PLLTUNE_Channel_1,
          2 => FS_PLLTUNE_Channel_2,
@@ -88,16 +86,16 @@ is
          4 => FS_PLLTUNE_Channel_4,
          5 => FS_PLLTUNE_Channel_5,
          7 => FS_PLLTUNE_Channel_7,
-         -- Note that channel 6 is not a valid channel. However, Channel_Number
-         -- cannot be used as the array index type since it has a predicate.
+         --  Note that channel 6 is not a valid channel. However, Channel_Number
+         --  cannot be used as the array index type since it has a predicate.
          6 => 0);
 
-   -- These values for FS_PLLCFG are ported from the C decadriver
+   --  These values for FS_PLLCFG are ported from the C decadriver
    FS_XTALT_Value : constant FS_XTALT_Type
      := (XTALT    => 16,
          Reserved => 2#011#);
 
-   -- These values for RF_TXCTRL are given by the user manual
+   --  These values for RF_TXCTRL are given by the user manual
    RF_TXCTRL_Values : constant array (Positive range 1 .. 7) of RF_TXCTRL_Field
      := (1 => RF_TXCTRL_Channel_1,
          2 => RF_TXCTRL_Channel_2,
@@ -105,19 +103,19 @@ is
          4 => RF_TXCTRL_Channel_4,
          5 => RF_TXCTRL_Channel_5,
          7 => RF_TXCTRL_Channel_7,
-         -- Note that channel 6 is not a valid channel. However, Channel_Number
-         -- cannot be used as the array index type since it has a predicate.
+         --  Note that channel 6 is not a valid channel. However, Channel_Number
+         --  cannot be used as the array index type since it has a predicate.
          6 => 0);
 
-   -- These values for RF_RXCTRLH are given by the user manual
+   --  These values for RF_RXCTRLH are given by the user manual
    RF_RXCTRLH_Values : constant array (Positive range 1 .. 7) of RF_RXCTRLH_Field
-     := (1..3|5 => RF_RXCTRLH_500MHz,
-         4|7    => RF_RXCTRLH_900MHz,
-         -- Note that channel 6 is not a valid channel. However, Channel_Number
-         -- cannot be used as the array index type since it has a predicate.
-         6      => 0);
+     := (1 .. 3 | 5 => RF_RXCTRLH_500MHz,
+         4 | 7      => RF_RXCTRLH_900MHz,
+         --  Note that channel 6 is not a valid channel. However, Channel_Number
+         --  cannot be used as the array index type since it has a predicate.
+         6          => 0);
 
-   -- These values for DRX_TUNE0b are given by the user manual
+   --  These values for DRX_TUNE0b are given by the user manual
    DRX_TUNE0b_Values : constant array (Data_Rates, Boolean) of DRX_TUNE0b_Field
      := (Data_Rate_110k => (False => DRX_TUNE0b_110K_STD,
                             True  => DRX_TUNE0b_110K_Non_STD),
@@ -126,12 +124,12 @@ is
          Data_Rate_6M8  => (False => DRX_TUNE0b_6M8_STD,
                             True  => DRX_TUNE0b_6M8_Non_STD));
 
-   -- These values for DRX_TUNE1a are given by the user manual
+   --  These values for DRX_TUNE1a are given by the user manual
    DRX_TUNE1a_Values : constant array (PRF_Type) of DRX_TUNE1a_Field
      := (PRF_16MHz => DRX_TUNE1a_16MHz,
          PRF_64MHz => DRX_TUNE1a_64MHz);
 
-   -- These values for DRX_TUNE2 are given by the user manual
+   --  These values for DRX_TUNE2 are given by the user manual
    DRX_TUNE2_Values : constant array (Preamble_Acq_Chunk_Length,
                                       PRF_Type) of DRX_TUNE2_Field
      := (PAC_8  => (PRF_16MHz => DRX_TUNE2_PAC8_16MHz,
@@ -143,12 +141,12 @@ is
          PAC_64 => (PRF_16MHz => DRX_TUNE2_PAC64_16MHz,
                     PRF_64MHz => DRX_TUNE2_PAC64_64MHz));
 
-   -- These values for AGC_TUNE1 are given by the user manual
+   --  These values for AGC_TUNE1 are given by the user manual
    AGC_TUNE1_Values : constant array (PRF_Type) of AGC_TUNE1_Field
      := (PRF_16MHz => AGC_TUNE1_PRF_16MHz,
          PRF_64MHz => AGC_TUNE1_PRF_64MHz);
 
-   -- These values for TC_PGDELAY are given by the user manual
+   --  These values for TC_PGDELAY are given by the user manual
    TC_PGDELAY_Values : constant array (Positive range 1 .. 7) of TC_PGDELAY_Field
      := (1 => TC_PGDELAY_Channel_1,
          2 => TC_PGDELAY_Channel_2,
@@ -158,11 +156,15 @@ is
          6 => 0,      --  Channel 6 not in Channel_Number
          7 => TC_PGDELAY_Channel_7);
 
-   -- This value for non-standard SFD lengths are given by the user manual
+   --  This value for non-standard SFD lengths are given by the user manual
    Non_Standard_SFD_Lengths : constant array (Data_Rates) of Types.Bits_8
      := (Data_Rate_110k => 64,
          Data_Rate_850k => 16,
          Data_Rate_6M8  => 8);
+
+   -------------------------
+   --  Load_LDE_From_ROM  --
+   -------------------------
 
    procedure Load_LDE_From_ROM
    is
@@ -223,6 +225,10 @@ is
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
    end Load_LDE_From_ROM;
 
+   ---------------------
+   --  Enable_Clocks  --
+   ---------------------
+
    procedure Enable_Clocks (Clock : in Clocks)
    is
       PMSC_CTRL0_Reg : PMSC_CTRL0_Type;
@@ -238,7 +244,7 @@ is
             PMSC_CTRL0_Reg.TXCLKS  := Auto;
             PMSC_CTRL0_Reg.FACE    := Disabled;
 
-            -- Need to write the above changes before setting GPCE
+            --  Need to write the above changes before setting GPCE
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
             PMSC_CTRL0_Reg.Reserved_1 := PMSC_CTRL0_Reg.Reserved_1 and 2#100#;
@@ -255,7 +261,7 @@ is
             PMSC_CTRL0_Reg.RXCLKS    := Force_PLL;
             PMSC_CTRL0_Reg.FACE      := Enabled;
 
-            -- Need to write the above changes before setting SOFTRESET
+            --  Need to write the above changes before setting SOFTRESET
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
             PMSC_CTRL0_Reg.SOFTRESET := PMSC_CTRL0_Reg.SOFTRESET or 2#1000#;
@@ -264,7 +270,7 @@ is
             PMSC_CTRL0_Reg.RXCLKS    := Auto;
             PMSC_CTRL0_Reg.FACE      := Disabled;
 
-            -- Need to write the above changes before clearing SOFTRESET
+            --  Need to write the above changes before clearing SOFTRESET
             PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
             PMSC_CTRL0_Reg.SOFTRESET := PMSC_CTRL0_Reg.SOFTRESET and 2#0111#;
@@ -284,6 +290,9 @@ is
 
    end Enable_Clocks;
 
+   ----------------
+   --  Read_OTP  --
+   ----------------
 
    procedure Read_OTP (Address : in     OTP_ADDR_Field;
                        Word    :    out Bits_32)
@@ -292,11 +301,11 @@ is
       RDAT_Reg : OTP_RDAT_Type;
 
    begin
-      -- Set OTP address to read
+      --  Set OTP address to read
       OTP_ADDR.Write (OTP_ADDR_Type'(OTP_ADDR => Address,
                                      Reserved => 0));
 
-      -- Trigger OTP read
+      --  Trigger OTP read
       CTRL_Reg := OTP_CTRL_Type'
         (OTPRDEN    => Enabled,
          OTPREAD    => Trigger_Read,
@@ -310,17 +319,20 @@ is
 
       OTP_CTRL.Write (CTRL_Reg);
 
-      -- OTPRDEN is not self-clearing. Also clear OPTREAD
+      --  OTPRDEN is not self-clearing. Also clear OPTREAD
       CTRL_Reg.OTPRDEN := Disabled;
       CTRL_Reg.OTPREAD := No_Action;
       OTP_CTRL.Write (CTRL_Reg);
 
-      -- Read back the OTP word
+      --  Read back the OTP word
       OTP_RDAT.Read (RDAT_Reg);
       Word := RDAT_Reg.OTP_RDAT;
 
    end Read_OTP;
 
+   -----------------
+   --  Read_EUID  --
+   -----------------
 
    procedure Read_EUID (EUID : out Bits_64)
    is
@@ -332,11 +344,19 @@ is
       EUID := EUI_Reg.EUI;
    end Read_EUID;
 
+   ------------------
+   --  Write_EUID  --
+   ------------------
+
    procedure Write_EUID (EUID : in Bits_64)
    is
    begin
-      EUI.Write ( (EUI => EUID) );
+      EUI.Write ((EUI => EUID));
    end Write_EUID;
+
+   -------------------
+   --  Read_PAN_ID  --
+   -------------------
 
    procedure Read_PAN_ID (PAN_ID : out Bits_16)
    is
@@ -346,6 +366,10 @@ is
       PANADR.Read (PANADR_Reg);
       PAN_ID := PANADR_Reg.PAN_ID;
    end Read_PAN_ID;
+
+   --------------------
+   --  Write_PAN_ID  --
+   --------------------
 
    procedure Write_PAN_ID (PAN_ID : in Bits_16)
    is
@@ -357,6 +381,10 @@ is
       PANADR.Write (PANADR_Reg);
    end Write_PAN_ID;
 
+   --------------------------
+   --  Read_Short_Address  --
+   --------------------------
+
    procedure Read_Short_Address (Short_Address : out Bits_16)
    is
       PANADR_Reg : PANADR_Type;
@@ -365,6 +393,10 @@ is
       PANADR.Read (PANADR_Reg);
       Short_Address := PANADR_Reg.SHORT_ADDR;
    end Read_Short_Address;
+
+   ---------------------------
+   --  Write_Short_Address  --
+   ---------------------------
 
    procedure Write_Short_Address (Short_Address : in Bits_16)
    is
@@ -375,6 +407,10 @@ is
       PANADR_Reg.SHORT_ADDR := Short_Address;
       PANADR.Write (PANADR_Reg);
    end Write_Short_Address;
+
+   -------------------------------------
+   --  Read_PAN_ID_And_Short_Address  --
+   -------------------------------------
 
    procedure Read_PAN_ID_And_Short_Address (PAN_ID        : out Bits_16;
                                             Short_Address : out Bits_16)
@@ -387,13 +423,21 @@ is
       Short_Address := PANADR_Reg.SHORT_ADDR;
    end Read_PAN_ID_And_Short_Address;
 
+   --------------------------------------
+   --  Write_PAN_ID_And_Short_Address  --
+   --------------------------------------
+
    procedure Write_PAN_ID_And_Short_Address (PAN_ID        : in Bits_16;
                                              Short_Address : in Bits_16)
    is
    begin
-      PANADR.Write ( (PAN_ID     => PAN_ID,
-                      SHORT_ADDR => Short_Address) );
+      PANADR.Write ((PAN_ID     => PAN_ID,
+                     SHORT_ADDR => Short_Address));
    end Write_PAN_ID_And_Short_Address;
+
+   -----------------------------
+   --  Read_Tx_Antenna_Delay  --
+   -----------------------------
 
    procedure Read_Tx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time)
    is
@@ -405,15 +449,19 @@ is
       Antenna_Delay := TX_ANTD_Reg.TX_ANTD;
    end Read_Tx_Antenna_Delay;
 
-
+   ------------------------------
+   --  Write_Tx_Antenna_Delay  --
+   ------------------------------
 
    procedure Write_Tx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
    is
    begin
-      TX_ANTD.Write ( (TX_ANTD => Antenna_Delay) );
+      TX_ANTD.Write ((TX_ANTD => Antenna_Delay));
    end Write_Tx_Antenna_Delay;
 
-
+   -----------------------------
+   --  Read_Rx_Antenna_Delay  --
+   -----------------------------
 
    procedure Read_Rx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time)
    is
@@ -425,14 +473,19 @@ is
       Antenna_Delay := LDE_RXANTD_Reg.LDE_RXANTD;
    end Read_Rx_Antenna_Delay;
 
-
+   ------------------------------
+   --  Write_Rx_Antenna_Delay  --
+   ------------------------------
 
    procedure Write_Rx_Antenna_Delay (Antenna_Delay : in Antenna_Delay_Time)
    is
    begin
-      LDE_RXANTD.Write ( (LDE_RXANTD => Antenna_Delay) );
+      LDE_RXANTD.Write ((LDE_RXANTD => Antenna_Delay));
    end Write_Rx_Antenna_Delay;
 
+   ---------------------
+   --  Configure_LDE  --
+   ---------------------
 
    procedure Configure_LDE (PRF              : in PRF_Type;
                             Rx_Preamble_Code : in Preamble_Code_Number;
@@ -448,29 +501,41 @@ is
 
       if Data_Rate = Data_Rate_110k then
          --  110 k data rate has special handling
-         LDE_REPC.Write ( (LDE_REPC => REPC_Coeff / 8) );
+         LDE_REPC.Write ((LDE_REPC => REPC_Coeff / 8));
 
       else
-         LDE_REPC.Write ( (LDE_REPC => REPC_Coeff) );
+         LDE_REPC.Write ((LDE_REPC => REPC_Coeff));
       end if;
 
    end Configure_LDE;
 
+   ---------------------
+   --  Configure_PLL  --
+   ---------------------
+
    procedure Configure_PLL (Channel : in Channel_Number)
    is
    begin
-      FS_PLLCFG.Write  ( (FS_PLLCFG  => FS_PLLCFG_Values  (Positive (Channel))) );
-      FS_PLLTUNE.Write ( (FS_PLLTUNE => FS_PLLTUNE_Values (Positive (Channel))) );
-      FS_XTALT.Write (FS_XTALT_Value);
+      FS_PLLCFG.Write  ((FS_PLLCFG  => FS_PLLCFG_Values  (Positive (Channel))));
+      FS_PLLTUNE.Write ((FS_PLLTUNE => FS_PLLTUNE_Values (Positive (Channel))));
+      FS_XTALT.Write   (FS_XTALT_Value);
    end Configure_PLL;
+
+   --------------------
+   --  Configure_RF  --
+   --------------------
 
    procedure Configure_RF (Channel : in Channel_Number)
    is
    begin
-      RF_RXCTRLH.Write ( (RF_RXCTRLH => RF_RXCTRLH_Values (Positive (Channel))) );
-      RF_TXCTRL.Write  ( (RF_TXCTRL  => RF_TXCTRL_Values (Positive (Channel))) );
+      RF_RXCTRLH.Write ((RF_RXCTRLH => RF_RXCTRLH_Values (Positive (Channel))));
+      RF_TXCTRL.Write  ((RF_TXCTRL  => RF_TXCTRL_Values (Positive (Channel))));
 
    end Configure_RF;
+
+   ---------------------
+   --  Configure_DRX  --
+   ---------------------
 
    procedure Configure_DRX (PRF                : in PRF_Type;
                             Data_Rate          : in Data_Rates;
@@ -480,35 +545,42 @@ is
                             Nonstandard_SFD    : in Boolean)
    is
    begin
-      DRX_TUNE0b.Write ( (DRX_TUNE0b => DRX_TUNE0b_Values (Data_Rate,
-                                                           Nonstandard_SFD)) );
-      DRX_TUNE1a.Write ( (DRX_TUNE1a => DRX_TUNE1a_Values (PRF)) );
+      DRX_TUNE0b.Write ((DRX_TUNE0b => DRX_TUNE0b_Values (Data_Rate,
+                                                          Nonstandard_SFD)));
+      DRX_TUNE1a.Write ((DRX_TUNE1a => DRX_TUNE1a_Values (PRF)));
 
       if Data_Rate = Data_Rate_110k then
-         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_110K) );
+         DRX_TUNE1b.Write ((DRX_TUNE1b => DRX_TUNE1b_110K));
 
       elsif Tx_Preamble_Length = PLEN_64 then
-         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_6M8) );
-         DRX_TUNE4H.Write ( (DRX_TUNE4H => DRX_TUNE4H_Preamble_64) );
+         DRX_TUNE1b.Write ((DRX_TUNE1b => DRX_TUNE1b_6M8));
+         DRX_TUNE4H.Write ((DRX_TUNE4H => DRX_TUNE4H_Preamble_64));
       else
-         DRX_TUNE1b.Write ( (DRX_TUNE1b => DRX_TUNE1b_850K_6M8) );
-         DRX_TUNE4H.Write ( (DRX_TUNE4H => DRX_TUNE4H_Others) );
+         DRX_TUNE1b.Write ((DRX_TUNE1b => DRX_TUNE1b_850K_6M8));
+         DRX_TUNE4H.Write ((DRX_TUNE4H => DRX_TUNE4H_Others));
       end if;
 
-      DRX_TUNE2.Write  ( (DRX_TUNE2  => DRX_TUNE2_Values (PAC, PRF)) );
-      DRX_SFDTOC.Write ( (DRX_SFDTOC => DRX_SFDTOC_Field (SFD_Timeout)) );
+      DRX_TUNE2.Write  ((DRX_TUNE2  => DRX_TUNE2_Values (PAC, PRF)));
+      DRX_SFDTOC.Write ((DRX_SFDTOC => DRX_SFDTOC_Field (SFD_Timeout)));
    end Configure_DRX;
 
+   ---------------------
+   --  Configure_AGC  --
+   ---------------------
 
    procedure Configure_AGC (PRF : in PRF_Type)
    is
    begin
 
-      AGC_TUNE2.Write ( (AGC_TUNE2 => AGC_TUNE2_Value) );
-      AGC_TUNE1.Write ( (AGC_TUNE1 => AGC_TUNE1_Values (PRF)) );
-      AGC_TUNE3.Write ( (AGC_TUNE3 => AGC_TUNE3_Value) );
+      AGC_TUNE2.Write ((AGC_TUNE2 => AGC_TUNE2_Value));
+      AGC_TUNE1.Write ((AGC_TUNE1 => AGC_TUNE1_Values (PRF)));
+      AGC_TUNE3.Write ((AGC_TUNE3 => AGC_TUNE3_Value));
 
    end Configure_AGC;
+
+   --------------------
+   --  Configure_TC  --
+   --------------------
 
    procedure Configure_TC (Channel : in Channel_Number)
    is
@@ -516,6 +588,10 @@ is
       TC_PGDELAY.Write
         ((TC_PGDELAY => TC_PGDELAY_Values (Positive (Channel))));
    end Configure_TC;
+
+   --------------------------
+   --  Configure_TX_FCTRL  --
+   --------------------------
 
    procedure Configure_TX_FCTRL (Frame_Length        : in Natural;
                                  Tx_Data_Rate        : in Data_Rates;
@@ -552,6 +628,10 @@ is
           IFSDELAY => TX_FCTRL_IFSDELAY_Field (Inter_Frame_Spacing)));
    end Configure_TX_FCTRL;
 
+   ---------------------------
+   --  Configure_CHAN_CTRL  --
+   ---------------------------
+
    procedure Configure_CHAN_CTRL
      (Tx_Channel              : in Channel_Number;
       Rx_Channel              : in Channel_Number;
@@ -581,6 +661,10 @@ is
                         Reserved => 0));
    end Configure_CHAN_CTRL;
 
+   ----------------------------------------
+   --  Configure_Nonstandard_SFD_Length  --
+   ----------------------------------------
+
    procedure Configure_Nonstandard_SFD_Length (Data_Rate : in Data_Rates)
    is
       USR_SFD_Reg : Register_Types.USR_SFD_Type;
@@ -591,6 +675,10 @@ is
       USR_SFD.Write (USR_SFD_Reg);
    end Configure_Nonstandard_SFD_Length;
 
+   ----------------------------------
+   --  Configure_Non_Standard_SFD  --
+   ----------------------------------
+
    procedure Configure_Non_Standard_SFD (Rx_SFD : in String;
                                          Tx_SFD : in String)
    is
@@ -600,7 +688,18 @@ is
       function Magnitude (SFD : in String) return Types.Bits_8
         with Pre =>
           (SFD'Length in 1 .. 8
-           and (for all I in SFD'Range => SFD (I) in '+' | '-' | '0'))
+           and (for all I in SFD'Range => SFD (I) in '+' | '-' | '0'));
+
+      function Polarity (SFD : in String) return Types.Bits_8
+        with Pre =>
+          (SFD'Length in 1 .. 8
+           and (for all I in SFD'Range => SFD (I) in '+' | '-' | '0'));
+
+      -----------------
+      --  Magnitude  --
+      -----------------
+
+      function Magnitude (SFD : in String) return Types.Bits_8
       is
          Result : Bits_8 := 0;
 
@@ -614,10 +713,11 @@ is
          return Result;
       end Magnitude;
 
+      ----------------
+      --  Polarity  --
+      ----------------
+
       function Polarity (SFD : in String) return Types.Bits_8
-        with Pre =>
-          (SFD'Length in 1 .. 8
-           and (for all I in SFD'Range => SFD (I) in '+' | '-' | '0'))
       is
          Result : Bits_8 := 0;
 
@@ -647,13 +747,13 @@ is
          USR_SFD_Reg.Sub_Registers :=
            (0 => Bits_8 (Tx_SFD'Length),
             1 => Magnitude (Tx_SFD (Tx_SFD'First     .. Tx_SFD'First + 7)),
-            2 => Magnitude (Tx_SFD (Tx_SFD'First + 8 .. Tx_SFD'Last     )),
+            2 => Magnitude (Tx_SFD (Tx_SFD'First + 8 .. Tx_SFD'Last)),
             3 => Polarity  (Tx_SFD (Tx_SFD'First     .. Tx_SFD'First + 7)),
-            4 => Polarity  (Tx_SFD (Tx_SFD'First + 8 .. Tx_SFD'Last     )),
+            4 => Polarity  (Tx_SFD (Tx_SFD'First + 8 .. Tx_SFD'Last)),
             5 => Magnitude (Rx_SFD (Rx_SFD'First     .. Rx_SFD'First + 7)),
-            6 => Magnitude (Rx_SFD (Rx_SFD'First + 8 .. Rx_SFD'Last     )),
+            6 => Magnitude (Rx_SFD (Rx_SFD'First + 8 .. Rx_SFD'Last)),
             7 => Polarity  (Rx_SFD (Rx_SFD'First     .. Rx_SFD'First + 7)),
-            8 => Polarity  (Rx_SFD (Rx_SFD'First + 8 .. Rx_SFD'Last     )),
+            8 => Polarity  (Rx_SFD (Rx_SFD'First + 8 .. Rx_SFD'Last)),
             others => 0);
 
       else
@@ -698,25 +798,35 @@ is
 
    end Configure_Non_Standard_SFD;
 
-   procedure Set_Frame_Filtering_Enabled (Enabled : in Boolean)
+   -----------------------------------
+   --  Set_Frame_Filtering_Enabled  --
+   -----------------------------------
+
+   procedure Set_Frame_Filtering_Enabled (Enable : in Boolean)
    is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.FFEN := (if Enabled
-                           then Register_Types.Enabled
-                           else Register_Types.Disabled);
+      SYS_CFG_Reg.FFEN := (if Enable then Enabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Frame_Filtering_Enabled;
 
-   procedure Set_FCS_Check_Enabled (Enabled : in Boolean)
+   -----------------------------
+   --  Set_FCS_Check_Enabled  --
+   -----------------------------
+
+   procedure Set_FCS_Check_Enabled (Enable : in Boolean)
    is
       SYS_CFG_Reg : SYS_CFG_Type;
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_FCE := (if Enabled then Not_Disabled else Disabled);
+      SYS_CFG_Reg.DIS_FCE := (if Enable then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_FCS_Check_Enabled;
+
+   ---------------------------------
+   --  Configure_Frame_Filtering  --
+   ---------------------------------
 
    procedure Configure_Frame_Filtering (Behave_As_Coordinator   : in Boolean;
                                         Allow_Beacon_Frame      : in Boolean;
@@ -741,19 +851,27 @@ is
       SYS_CFG.Write (SYS_CFG_Reg);
    end Configure_Frame_Filtering;
 
-   procedure Set_Smart_Tx_Power (Enabled : in Boolean)
+   --------------------------
+   --  Set_Smart_Tx_Power  --
+   --------------------------
+
+   procedure Set_Smart_Tx_Power (Enable : in Boolean)
    is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_STXP := (if Enabled then Not_Disabled else Disabled);
+      SYS_CFG_Reg.DIS_STXP := (if Enable then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Smart_Tx_Power;
 
-   procedure Read_OTP_Tx_Power_Level (Channel  : in     Channel_Number;
-                                      PRF      : in     PRF_Type;
-                                      Tx_Power :    out TX_POWER_Type)
+   -------------------------------
+   --  Read_OTP_Tx_Power_Level  --
+   -------------------------------
+
+   procedure Read_OTP_Tx_Power_Level (Channel     : in     Channel_Number;
+                                      PRF         : in     PRF_Type;
+                                      Power_Level :    out TX_POWER_Type)
    is
       Address : OTP_ADDR_Field;
       Word    : Bits_32;
@@ -779,8 +897,12 @@ is
       Read_OTP (Address => Address,
                 Word    => Word);
 
-      Tx_Power := Word_To_TX_POWER (Word);
+      Power_Level := Word_To_TX_POWER (Word);
    end Read_OTP_Tx_Power_Level;
+
+   ------------------------------
+   --  Read_OTP_Antenna_Delay  --
+   ------------------------------
 
    procedure Read_OTP_Antenna_Delay
      (Antenna_Delay_16_MHz : out Antenna_Delay_Time;
@@ -800,6 +922,10 @@ is
       Antenna_Delay_16_MHz := To_Antenna_Delay_Time (Lo);
       Antenna_Delay_64_MHz := To_Antenna_Delay_Time (Hi);
    end Read_OTP_Antenna_Delay;
+
+   --------------------------
+   --  Configure_Tx_Power  --
+   --------------------------
 
    procedure Configure_Tx_Power (Config : Tx_Power_Config_Type)
    is
@@ -829,6 +955,10 @@ is
       SYS_CFG.Write (SYS_CFG_Reg);
    end Configure_Tx_Power;
 
+   -------------------
+   --  Set_Tx_Data  --
+   -------------------
+
    procedure Set_Tx_Data (Data   : in Types.Byte_Array;
                           Offset : in Natural)
    is
@@ -840,6 +970,10 @@ is
             Data        => Data);
       end if;
    end Set_Tx_Data;
+
+   ---------------------------
+   --  Set_Tx_Frame_Length  --
+   ---------------------------
 
    procedure Set_Tx_Frame_Length (Length : in Natural;
                                   Offset : in Natural)
@@ -854,6 +988,10 @@ is
       TX_FCTRL.Write (TX_FCTRL_Reg);
 
    end Set_Tx_Frame_Length;
+
+   --------------------------
+   --  Start_Tx_Immediate  --
+   --------------------------
 
    procedure Start_Tx_Immediate (Rx_After_Tx     : in Boolean;
                                  Auto_Append_FCS : in Boolean)
@@ -877,6 +1015,10 @@ is
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
    end Start_Tx_Immediate;
+
+   ------------------------
+   --  Start_Tx_Delayed  --
+   ------------------------
 
    procedure Start_Tx_Delayed (Rx_After_Tx : in     Boolean;
                                Result      :    out Result_Type)
@@ -907,7 +1049,7 @@ is
          Result := Success;
 
       else
-         -- Cancel the transmit
+         --  Cancel the transmit
          SYS_CTRL_Reg := SYS_CTRL_Type'(SFCST      => Not_Suppressed,
                                         TXSTRT     => No_Action,
                                         TXDLYS     => Not_Delayed,
@@ -922,12 +1064,16 @@ is
                                         Reserved_3 => 0);
          SYS_CTRL.Write (SYS_CTRL_Reg);
 
-         Set_Sleep_After_Tx (Enabled => False);
+         Set_Sleep_After_Tx (Enable => False);
 
          Result := Error;
       end if;
 
    end Start_Tx_Delayed;
+
+   --------------------
+   --  Read_Rx_Data  --
+   --------------------
 
    procedure Read_Rx_Data (Data   :    out Types.Byte_Array;
                            Offset : in     Natural)
@@ -939,23 +1085,33 @@ is
          Data        => Data);
    end Read_Rx_Data;
 
+   ------------------------------
+   --  Set_Delayed_Tx_Rx_Time  --
+   ------------------------------
+
    procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time)
    is
    begin
       DX_TIME.Write (DX_TIME_Type'(DX_TIME => Delay_Time));
    end Set_Delayed_Tx_Rx_Time;
 
-   procedure Set_Sleep_After_Tx (Enabled : in Boolean)
+   --------------------------
+   --  Set_Sleep_After_Tx  --
+   --------------------------
+
+   procedure Set_Sleep_After_Tx (Enable : in Boolean)
    is
       PMSC_CTRL1_Reg : PMSC_CTRL1_Type;
 
    begin
       PMSC_CTRL1.Read (PMSC_CTRL1_Reg);
-      PMSC_CTRL1_Reg.ATXSLP := (if Enabled
-                                then Register_Types.Enabled
-                                else Register_Types.Disabled);
+      PMSC_CTRL1_Reg.ATXSLP := (if Enable then Enabled else Disabled);
       PMSC_CTRL1.Write (PMSC_CTRL1_Reg);
    end Set_Sleep_After_Tx;
+
+   ----------------------------------
+   --  Read_Rx_Adjusted_Timestamp  --
+   ----------------------------------
 
    procedure Read_Rx_Adjusted_Timestamp (Timestamp : out Fine_System_Time)
    is
@@ -966,21 +1122,27 @@ is
       Timestamp := RX_TIME_Reg.RX_STAMP;
    end Read_Rx_Adjusted_Timestamp;
 
+   -----------------------------
+   --  Read_Rx_Raw_Timestamp  --
+   -----------------------------
 
    procedure Read_Rx_Raw_Timestamp (Timestamp : out Coarse_System_Time)
    is
-      RX_Time_Reg : RX_Time_Type;
+      RX_TIME_Reg : RX_TIME_Type;
 
    begin
       RX_TIME.Read (RX_TIME_Reg);
       Timestamp := RX_TIME_Reg.RX_RAWST;
    end Read_Rx_Raw_Timestamp;
 
+   --------------------------
+   --  Read_Rx_Timestamps  --
+   --------------------------
 
    procedure Read_Rx_Timestamps (Adjusted : out Fine_System_Time;
                                  Raw      : out Coarse_System_Time)
    is
-      RX_Time_Reg : RX_Time_Type;
+      RX_TIME_Reg : RX_TIME_Type;
 
    begin
       RX_TIME.Read (RX_TIME_Reg);
@@ -988,6 +1150,9 @@ is
       Raw      := RX_TIME_Reg.RX_RAWST;
    end Read_Rx_Timestamps;
 
+   ----------------------------------
+   --  Read_Tx_Adjusted_Timestamp  --
+   ----------------------------------
 
    procedure Read_Tx_Adjusted_Timestamp (Timestamp : out Fine_System_Time)
    is
@@ -998,21 +1163,27 @@ is
       Timestamp := TX_TIME_Reg.TX_STAMP;
    end Read_Tx_Adjusted_Timestamp;
 
+   -----------------------------
+   --  Read_Tx_Raw_Timestamp  --
+   -----------------------------
 
    procedure Read_Tx_Raw_Timestamp (Timestamp : out Coarse_System_Time)
    is
-      TX_Time_Reg : TX_Time_Type;
+      TX_TIME_Reg : TX_TIME_Type;
 
    begin
       TX_TIME.Read (TX_TIME_Reg);
       Timestamp := TX_TIME_Reg.TX_RAWST;
    end Read_Tx_Raw_Timestamp;
 
+   --------------------------
+   --  Read_Tx_Timestamps  --
+   --------------------------
 
    procedure Read_Tx_Timestamps (Adjusted : out Fine_System_Time;
                                  Raw      : out Coarse_System_Time)
    is
-      TX_Time_Reg : TX_Time_Type;
+      TX_TIME_Reg : TX_TIME_Type;
 
    begin
       TX_TIME.Read (TX_TIME_Reg);
@@ -1020,6 +1191,9 @@ is
       Raw      := TX_TIME_Reg.TX_RAWST;
    end Read_Tx_Timestamps;
 
+   -----------------------------
+   --  Read_System_Timestamp  --
+   -----------------------------
 
    procedure Read_System_Timestamp (Timestamp : out Coarse_System_Time)
    is
@@ -1030,6 +1204,10 @@ is
       Timestamp := SYS_TIME_Reg.SYS_TIME;
    end Read_System_Timestamp;
 
+   ---------------------
+   --  Check_Overrun  --
+   ---------------------
+
    procedure Check_Overrun (Overrun : out Boolean)
    is
       SYS_STATUS_Reg : SYS_STATUS_Type;
@@ -1039,20 +1217,24 @@ is
       Overrun := SYS_STATUS_Reg.RXOVRR = 1;
    end Check_Overrun;
 
+   -----------------------
+   --  Force_Tx_Rx_Off  --
+   -----------------------
+
    procedure Force_Tx_Rx_Off
    is
       SYS_MASK_Reg : SYS_MASK_Type;
 
    begin
-      -- Temporarily disable all interrupts
+      --  Temporarily disable all interrupts
       SYS_MASK.Read (SYS_MASK_Reg);
       SYS_MASK.Write (SYS_MASK_Type'(others => <>));
 
-      -- Disable Tx/Rx
+      --  Force transceiver off;
       SYS_CTRL.Write (SYS_CTRL_Type'(TRXOFF => Transceiver_Off,
                                      others => <>));
 
-      -- Force transceiver off; don't want to see any new events.
+      --  Clear any pending events.
       SYS_STATUS.Write (SYS_STATUS_Type'(AAT        => 1,
                                          TXFRB      => 1,
                                          TXPRS      => 1,
@@ -1078,10 +1260,14 @@ is
 
       Sync_Rx_Buffer_Pointers;
 
-      -- Restore previous interrupt settings.
+      --  Restore previous interrupt settings.
       SYS_MASK.Write (SYS_MASK_Reg);
 
    end Force_Tx_Rx_Off;
+
+   ----------------
+   --  Reset_Rx  --
+   ----------------
 
    procedure Reset_Rx
    is
@@ -1101,6 +1287,10 @@ is
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
    end Reset_Rx;
 
+   ------------------------------------------
+   --  Toggle_Host_Side_Rx_Buffer_Pointer  --
+   ------------------------------------------
+
    procedure Toggle_Host_Side_Rx_Buffer_Pointer
    is
       SYS_CTRL_Reg   : SYS_CTRL_Type;
@@ -1110,6 +1300,10 @@ is
       SYS_CTRL.Write (SYS_CTRL_Reg);
    end Toggle_Host_Side_Rx_Buffer_Pointer;
 
+   -------------------------------
+   --  Sync_Rx_Buffer_Pointers  --
+   -------------------------------
+
    procedure Sync_Rx_Buffer_Pointers
    is
       SYS_STATUS_Reg : SYS_STATUS_Type;
@@ -1117,14 +1311,17 @@ is
    begin
       SYS_STATUS.Read (SYS_STATUS_Reg);
 
-      -- Check if the IC side receive buffer pointer is the same
-      -- as the host side receive buffer pointer.
+      --  Check if the IC side receive buffer pointer is the same
+      --  as the host side receive buffer pointer.
       if SYS_STATUS_Reg.ICRBP /= SYS_STATUS_Reg.HSRBP then
          Toggle_Host_Side_Rx_Buffer_Pointer;
       end if;
 
    end Sync_Rx_Buffer_Pointers;
 
+   --------------------------
+   --  Start_Rx_Immediate  --
+   --------------------------
 
    procedure Start_Rx_Immediate
    is
@@ -1151,6 +1348,9 @@ is
 
    end Start_Rx_Immediate;
 
+   ------------------------
+   --  Start_Rx_Delayed  --
+   ------------------------
 
    procedure Start_Rx_Delayed (Result  : out Result_Type)
    is
@@ -1176,13 +1376,13 @@ is
 
       SYS_CTRL.Write (SYS_CTRL_Reg);
 
-      -- Check for errors
+      --  Check for errors
       SYS_STATUS.Read (SYS_STATUS_Reg);
 
       if SYS_STATUS_Reg.HPDWARN = 1 then
          Force_Tx_Rx_Off;
 
-         -- Clear the delay bit
+         --  Clear the delay bit
          SYS_CTRL_Reg.RXDLYE := Not_Delayed;
          SYS_CTRL.Write (SYS_CTRL_Reg);
 
@@ -1193,6 +1393,10 @@ is
       end if;
 
    end Start_Rx_Delayed;
+
+   -------------------
+   --  Set_Rx_Mode  --
+   -------------------
 
    procedure Set_Rx_Mode (Mode        : in Rx_Modes;
                           Rx_On_Time  : in RX_SNIFF_SNIFF_ONT_Field;
@@ -1216,27 +1420,37 @@ is
 
    end Set_Rx_Mode;
 
-   procedure Set_Auto_Rx_Reenable (Enabled : in Boolean)
+   ----------------------------
+   --  Set_Auto_Rx_Reenable  --
+   ----------------------------
+
+   procedure Set_Auto_Rx_Reenable (Enable : in Boolean)
    is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.RXAUTR := (if Enabled
-                             then Register_Types.Enabled
-                             else Register_Types.Disabled);
+      SYS_CFG_Reg.RXAUTR := (if Enable then Enabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Auto_Rx_Reenable;
 
-   procedure Set_Rx_Double_Buffer (Enabled : in Boolean)
+   ----------------------------
+   --  Set_Rx_Double_Buffer  --
+   ----------------------------
+
+   procedure Set_Rx_Double_Buffer (Enable : in Boolean)
    is
       SYS_CFG_Reg : SYS_CFG_Type;
 
    begin
       SYS_CFG.Read (SYS_CFG_Reg);
-      SYS_CFG_Reg.DIS_DRXB := (if Enabled then Not_Disabled else Disabled);
+      SYS_CFG_Reg.DIS_DRXB := (if Enable then Not_Disabled else Disabled);
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Rx_Double_Buffer;
+
+   ---------------------------------
+   --  Set_Rx_Frame_Wait_Timeout  --
+   ---------------------------------
 
    procedure Set_Rx_Frame_Wait_Timeout (Timeout : in Frame_Wait_Timeout_Time)
    is
@@ -1248,7 +1462,7 @@ is
       if Timeout > 0.0 then
          SYS_CFG_Reg.RXWTOE := Enabled;
 
-         RX_FWTO.Write ( (RXFWTO => Timeout) );
+         RX_FWTO.Write ((RXFWTO => Timeout));
 
       else
          SYS_CFG_Reg.RXWTOE := Disabled;
@@ -1258,11 +1472,19 @@ is
       SYS_CFG.Write (SYS_CFG_Reg);
    end Set_Rx_Frame_Wait_Timeout;
 
-   procedure Set_Preamble_Detect_Timeout (Timeout : in Types.Bits_16)
+   -----------------------------------
+   --  Set_Preamble_Detect_Timeout  --
+   -----------------------------------
+
+   procedure Set_Preamble_Detect_Timeout (Timeout : in DRX_PRETOC_Field)
    is
    begin
-      DRX_PRETOC.Write ( (DRX_PRETOC => DRX_PRETOC_Field (Timeout)) );
+      DRX_PRETOC.Write ((DRX_PRETOC => Timeout));
    end Set_Preamble_Detect_Timeout;
+
+   -----------------------------
+   --  Calibrate_Sleep_Count  --
+   -----------------------------
 
    procedure Calibrate_Sleep_Count
      (Half_XTAL_Cycles_Per_LP_Osc_Cycle : out Types.Bits_16)
@@ -1272,14 +1494,14 @@ is
       Data : Types.Byte_Array (1 .. 2);
 
    begin
-      -- Enable calibration
+      --  Enable calibration
       AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
                                      SMXX     => Clear,
                                      LPOSC_C  => Enabled,
                                      Reserved => 0));
       Upload_AON_Config;
 
-      -- Disable calibration
+      --  Disable calibration
       AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Disabled,
                                      SMXX     => Clear,
                                      LPOSC_C  => Disabled,
@@ -1291,7 +1513,7 @@ is
       PMSC_CTRL0_Reg.RXCLKS  := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
-      -- Read number of XTAL/2 cycles per LP osc cycle
+      --  Read number of XTAL/2 cycles per LP osc cycle
       AON_Contiguous_Read (Start_Address => 117,
                            Data          => Data);
 
@@ -1299,11 +1521,15 @@ is
         := (Types.Bits_16 (Data (1))
             or Shift_Left (Types.Bits_16 (Data (2)), 8));
 
-      -- Reset PMSC_CTRL0
+      --  Reset PMSC_CTRL0
       PMSC_CTRL0_Reg.SYSCLKS := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
    end Calibrate_Sleep_Count;
+
+   -------------------------
+   --  Upload_AON_Config  --
+   -------------------------
 
    procedure Upload_AON_Config
    is
@@ -1322,6 +1548,10 @@ is
                                      Reserved => 0));
    end Upload_AON_Config;
 
+   -----------------------------
+   --  Save_Registers_To_AON  --
+   -----------------------------
+
    procedure Save_Registers_To_AON
    is
    begin
@@ -1332,6 +1562,10 @@ is
                                      DCA_ENAB => Disabled,
                                      Reserved => 0));
    end Save_Registers_To_AON;
+
+   ----------------------------------
+   --  Restore_Registers_From_AON  --
+   ----------------------------------
 
    procedure Restore_Registers_From_AON
    is
@@ -1344,16 +1578,20 @@ is
                                      Reserved => 0));
    end Restore_Registers_From_AON;
 
+   ---------------------
+   --  AON_Read_Byte  --
+   ---------------------
+
    procedure AON_Read_Byte (Address : in     AON_ADDR_Field;
                             Data    :    out Types.Bits_8)
    is
       AON_RDAT_Reg : AON_RDAT_Type;
 
    begin
-      -- Load address
+      --  Load address
       AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
 
-      -- Enable DCA_ENAB
+      --  Enable DCA_ENAB
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
                                      UPL_CFG  => No_Action,
@@ -1361,7 +1599,7 @@ is
                                      DCA_ENAB => Enabled,
                                      Reserved => 0));
 
-      -- Now also enable DCA_READ
+      --  Now also enable DCA_READ
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
                                      UPL_CFG  => No_Action,
@@ -1369,11 +1607,11 @@ is
                                      DCA_ENAB => Enabled,
                                      Reserved => 0));
 
-      -- Read the result
+      --  Read the result
       AON_RDAT.Read (AON_RDAT_Reg);
       Data := AON_RDAT_Reg.AON_RDAT;
 
-      -- Clear DCA_ENAB and DCA_READ
+      --  Clear DCA_ENAB and DCA_READ
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
                                      UPL_CFG  => No_Action,
@@ -1381,6 +1619,10 @@ is
                                      DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Read_Byte;
+
+   ---------------------------
+   --  AON_Contiguous_Read  --
+   ---------------------------
 
    procedure AON_Contiguous_Read (Start_Address : in     AON_ADDR_Field;
                                   Data          :    out Types.Byte_Array)
@@ -1390,10 +1632,10 @@ is
 
    begin
       for I in Data'Range loop
-         -- Load address
+         --  Load address
          AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Address));
 
-         -- Enable DCA_ENAB
+         --  Enable DCA_ENAB
          AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                         SAVE     => No_Action,
                                         UPL_CFG  => No_Action,
@@ -1401,7 +1643,7 @@ is
                                         DCA_ENAB => Enabled,
                                         Reserved => 0));
 
-         -- Now also enable DCA_READ
+         --  Now also enable DCA_READ
          AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                         SAVE     => No_Action,
                                         UPL_CFG  => No_Action,
@@ -1409,14 +1651,14 @@ is
                                         DCA_ENAB => Enabled,
                                         Reserved => 0));
 
-         -- Read the result
+         --  Read the result
          AON_RDAT.Read (AON_RDAT_Reg);
          Data (I) := AON_RDAT_Reg.AON_RDAT;
 
          Address := Address + 1;
       end loop;
 
-      -- Clear DCA_ENAB and DCA_READ
+      --  Clear DCA_ENAB and DCA_READ
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
                                      UPL_CFG  => No_Action,
@@ -1424,6 +1666,10 @@ is
                                      DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Contiguous_Read;
+
+   ------------------------
+   --  AON_Scatter_Read  --
+   ------------------------
 
    procedure AON_Scatter_Read (Addresses : in     AON_Address_Array;
                                Data      :    out Types.Byte_Array)
@@ -1437,10 +1683,10 @@ is
       Data := (others => 0); -- workaround for flow analysis.
 
       for I in 0 .. Data'Length - 1 loop
-         -- Load address
+         --  Load address
          AON_ADDR.Write (AON_ADDR_Type'(AON_ADDR => Addresses (A_First + I)));
 
-         -- Enable DCA_ENAB
+         --  Enable DCA_ENAB
          AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                         SAVE     => No_Action,
                                         UPL_CFG  => No_Action,
@@ -1448,7 +1694,7 @@ is
                                         DCA_ENAB => Enabled,
                                         Reserved => 0));
 
-         -- Now also enable DCA_READ
+         --  Now also enable DCA_READ
          AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                         SAVE     => No_Action,
                                         UPL_CFG  => No_Action,
@@ -1456,12 +1702,12 @@ is
                                         DCA_ENAB => Enabled,
                                         Reserved => 0));
 
-         -- Read the result
+         --  Read the result
          AON_RDAT.Read (AON_RDAT_Reg);
          Data (D_First + I) := AON_RDAT_Reg.AON_RDAT;
       end loop;
 
-      -- Clear DCA_ENAB and DCA_READ
+      --  Clear DCA_ENAB and DCA_READ
       AON_CTRL.Write (AON_CTRL_Type'(RESTORE  => No_Action,
                                      SAVE     => No_Action,
                                      UPL_CFG  => No_Action,
@@ -1469,6 +1715,10 @@ is
                                      DCA_ENAB => Disabled,
                                      Reserved => 0));
    end AON_Scatter_Read;
+
+   -----------------------------
+   --  Configure_Sleep_Count  --
+   -----------------------------
 
    procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field)
    is
@@ -1480,7 +1730,7 @@ is
       PMSC_CTRL0_Reg.RXCLKS  := Auto;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
-      -- Make sure we don't accidentally sleep
+      --  Make sure we don't accidentally sleep
       AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
                                      WAKE_PIN  => Disabled,
                                      WAKE_SPI  => Disabled,
@@ -1494,10 +1744,10 @@ is
                                      LPOSC_C  => Disabled,
                                      Reserved => 0));
 
-      -- Disable the sleep counter
+      --  Disable the sleep counter
       Upload_AON_Config;
 
-      -- Set the new value
+      --  Set the new value
       AON_CFG0.Write (AON_CFG0_Type'(SLEEP_EN  => Disabled,
                                      WAKE_PIN  => Disabled,
                                      WAKE_SPI  => Disabled,
@@ -1507,7 +1757,7 @@ is
                                      SLEEP_TIM => Sleep_Count));
       Upload_AON_Config;
 
-      -- Enable the new value
+      --  Enable the new value
       AON_CFG1.Write (AON_CFG1_Type'(SLEEP_CE => Enabled,
                                      SMXX     => Clear,
                                      LPOSC_C  => Disabled,
@@ -1518,6 +1768,9 @@ is
 
    end Configure_Sleep_Count;
 
+   ---------------------
+   --  Set_XTAL_Trim  --
+   ---------------------
 
    procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field)
    is
@@ -1528,6 +1781,10 @@ is
       FS_XTALT_Reg.XTALT := Trim;
       FS_XTALT.Write (FS_XTALT_Reg);
    end Set_XTAL_Trim;
+
+   ----------------------
+   --  Configure_LEDs  --
+   ----------------------
 
    procedure Configure_LEDs (Tx_LED_Enable    : in Boolean;
                              Rx_LED_Enable    : in Boolean;
@@ -1558,7 +1815,7 @@ is
       PMSC_CTRL0_Reg.KHZCLKEN := Enabled;
       PMSC_CTRL0.Write (PMSC_CTRL0_Reg);
 
-      -- Enable LEDs
+      --  Enable LEDs
       PMSC_LEDC.Read (PMSC_LEDC_Reg);
       PMSC_LEDC_Reg.BLINK_TIM := 0.224;
       PMSC_LEDC_Reg.BLNKEN    := (if LED_Enabled then Enabled else Disabled);

--- a/src/dw1000-driver.ads
+++ b/src/dw1000-driver.ads
@@ -59,7 +59,7 @@ is
       Data_Rate_6M8  => 2#10#);
 
    type Channel_Number is range 1 .. 7
-     with Static_Predicate => Channel_Number in 1..5 | 7;
+     with Static_Predicate => Channel_Number in 1 .. 5 | 7;
    --  Channels 1 .. 5 and 7 are supported by the DW1000.
 
    type PRF_Type is (PRF_16MHz, PRF_64MHz);
@@ -128,7 +128,6 @@ is
           when PAC_32 => 32,
           when PAC_64 => 64);
 
-
    function To_Positive (Preamble_Length : in Preamble_Lengths) return Positive
    is (case Preamble_Length is
           when PLEN_64   => 64,
@@ -155,7 +154,6 @@ is
    --  on the preamble length.
    --
    --  These recommendations are from Section 4.1.1 of the DW1000 User Manual.
-
 
    function Recommended_SFD_Timeout
      (Preamble_Length : in Preamble_Lengths;
@@ -198,7 +196,7 @@ is
 
    procedure Enable_Clocks (Clock : in Clocks)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Clock);
+     Depends => (DW1000.BSP.Device_State =>+ Clock);
    --  Enables and configures the specified clock.
    --
    --  This procedure configures the following registers:
@@ -214,14 +212,14 @@ is
    --  The package DW1000.Constants defines the addresses used to store the
    --  various data stored in the OTP memory.
 
-   procedure Read_OTP_Tx_Power_Level (Channel  : in     Channel_Number;
-                                      PRF      : in     PRF_Type;
-                                      Tx_Power :    out TX_POWER_Type)
+   procedure Read_OTP_Tx_Power_Level (Channel     : in     Channel_Number;
+                                      PRF         : in     PRF_Type;
+                                      Power_Level :    out TX_POWER_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
                                              Channel,
                                              PRF),
-                 Tx_Power                => (DW1000.BSP.Device_State,
+                 Power_Level             => (DW1000.BSP.Device_State,
                                              Channel,
                                              PRF));
 
@@ -235,7 +233,7 @@ is
 
    procedure Configure_Tx_Power (Config : Tx_Power_Config_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Config);
+     Depends => (DW1000.BSP.Device_State =>+ Config);
    --  Configure the transmit power of the DW1000 transmitter.
    --
    --  This procedure is used to configure both smart transmit power and
@@ -284,7 +282,7 @@ is
 
    procedure Write_EUID (EUID : in Bits_64)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + EUID);
+     Depends => (DW1000.BSP.Device_State =>+ EUID);
    --  Write the extended unique identifier (EUID).
 
    procedure Read_PAN_ID (PAN_ID : out Bits_16)
@@ -293,7 +291,7 @@ is
 
    procedure Write_PAN_ID (PAN_ID : in Bits_16)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + PAN_ID);
+     Depends => (DW1000.BSP.Device_State =>+ PAN_ID);
 
    procedure Read_Short_Address (Short_Address : out Bits_16)
      with Global => (In_Out => DW1000.BSP.Device_State),
@@ -302,7 +300,7 @@ is
 
    procedure Write_Short_Address (Short_Address : in Bits_16)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Short_Address);
+     Depends => (DW1000.BSP.Device_State =>+ Short_Address);
 
    procedure Read_PAN_ID_And_Short_Address (PAN_ID        : out Bits_16;
                                             Short_Address : out Bits_16)
@@ -314,7 +312,7 @@ is
    procedure Write_PAN_ID_And_Short_Address (PAN_ID        : in Bits_16;
                                              Short_Address : in Bits_16)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (PAN_ID, Short_Address));
+     Depends => (DW1000.BSP.Device_State =>+ (PAN_ID, Short_Address));
 
    procedure Read_Tx_Antenna_Delay (Antenna_Delay : out Antenna_Delay_Time)
      with Global => (In_Out => DW1000.BSP.Device_State),
@@ -434,7 +432,7 @@ is
 
    procedure Configure_AGC (PRF : in PRF_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + PRF);
+     Depends => (DW1000.BSP.Device_State =>+ PRF);
    --  Configures the automatic gain control (AGC) subsystem.
    --
    --  This procedure configures the following registers:
@@ -443,7 +441,7 @@ is
 
    procedure Configure_TC (Channel : in Channel_Number)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Channel);
+     Depends => (DW1000.BSP.Device_State =>+ Channel);
    --  Configure the transmit calibration (TC) block for the specified channel.
 
    procedure Configure_TX_FCTRL (Frame_Length        : in Natural;
@@ -468,7 +466,6 @@ is
         and then Frame_Length + Tx_Buffer_Offset <= Constants.TX_BUFFER_Length
         and then Inter_Frame_Spacing < 256);
 
-
    procedure Configure_CHAN_CTRL
      (Tx_Channel              : in Channel_Number;
       Rx_Channel              : in Channel_Number;
@@ -491,10 +488,9 @@ is
      Pre => ((if Use_Tx_User_Defined_SFD then not Use_DecaWave_SFD)
              and (if Use_Rx_User_Defined_SFD then not Use_DecaWave_SFD));
 
-
    procedure Configure_Nonstandard_SFD_Length (Data_Rate : in Data_Rates)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Data_Rate);
+     Depends => (DW1000.BSP.Device_State =>+ Data_Rate);
    --  Configures the length of the non-standard SFD for the specified
    --  data rate.
    --
@@ -504,7 +500,7 @@ is
    procedure Configure_Non_Standard_SFD (Rx_SFD : in String;
                                          Tx_SFD : in String)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Rx_SFD, Tx_SFD)),
+     Depends => (DW1000.BSP.Device_State =>+ (Rx_SFD, Tx_SFD)),
      Pre => (Rx_SFD'Length in 8 .. 16 | 64
              and Tx_SFD'Length = Rx_SFD'Length
              and (for all I in Rx_SFD'Range => Rx_SFD (I) in '+' | '-' | '0')
@@ -531,9 +527,9 @@ is
    --
    --  @param Tx_SFD The SFD sequence to use in the transmitter.
 
-   procedure Set_Frame_Filtering_Enabled (Enabled : in Boolean)
+   procedure Set_Frame_Filtering_Enabled (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Enable or disable frame filtering.
    --
    --  Frame filtering allows the DW1000 to automatically reject frames
@@ -546,9 +542,9 @@ is
    --  @param Enabled When set to True frame filtering is enabled. Otherwise,
    --     it is disabled.
 
-   procedure Set_FCS_Check_Enabled (Enabled : in Boolean)
+   procedure Set_FCS_Check_Enabled (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Enable or disable the automatic frame check sequence (FCS) on received
    --  frames.
    --
@@ -628,9 +624,9 @@ is
    --     When set to False and when frame filtering is enabled the DW1000
    --     will reject these frames.
 
-   procedure Set_Smart_Tx_Power (Enabled : in Boolean)
+   procedure Set_Smart_Tx_Power (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Enables or disables smart Tx power control.
    --
    --  Regulations for UWB typically specify a maximum transmit power limit of
@@ -647,7 +643,6 @@ is
    --
    --  This procedure configures the following registers:
    --    * SYS_CFG
-
 
    procedure Set_Tx_Data (Data   : in Types.Byte_Array;
                           Offset : in Natural)
@@ -674,7 +669,7 @@ is
    procedure Set_Tx_Frame_Length (Length : in Natural;
                                   Offset : in Natural)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Length, Offset)),
+     Depends => (DW1000.BSP.Device_State =>+ (Length, Offset)),
      Pre => (Length < DW1000.Constants.TX_BUFFER_Length
              and then Offset < DW1000.Constants.TX_BUFFER_Length
              and then Length + Offset <= DW1000.Constants.TX_BUFFER_Length);
@@ -687,7 +682,7 @@ is
    procedure Read_Rx_Data (Data   :    out Types.Byte_Array;
                            Offset : in     Natural)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Offset, Data),
+     Depends => (DW1000.BSP.Device_State =>+ (Offset, Data),
                  Data                    => (DW1000.BSP.Device_State, Offset)),
      Pre =>
        (Data'Length > 0
@@ -699,12 +694,12 @@ is
    procedure Start_Tx_Immediate (Rx_After_Tx     : in Boolean;
                                  Auto_Append_FCS : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Rx_After_Tx, Auto_Append_FCS));
+     Depends => (DW1000.BSP.Device_State =>+ (Rx_After_Tx, Auto_Append_FCS));
 
    procedure Start_Tx_Delayed (Rx_After_Tx : in     Boolean;
                                Result      :    out Result_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Rx_After_Tx,
+     Depends => (DW1000.BSP.Device_State =>+ Rx_After_Tx,
                  Result                  => (DW1000.BSP.Device_State,
                                              Rx_After_Tx));
    --  Transmit the contents of the TX buffer with a delay.
@@ -720,7 +715,7 @@ is
 
    procedure Set_Delayed_Tx_Rx_Time (Delay_Time : in Coarse_System_Time)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Delay_Time);
+     Depends => (DW1000.BSP.Device_State =>+ Delay_Time);
    --  Set the receive and transmit delay.
    --
    --  Both Rx and Tx share the same delay. It is not possible for the receiver
@@ -736,9 +731,9 @@ is
    --  This procedure configures the following registers:
    --    * DX_TIME
 
-   procedure Set_Sleep_After_Tx (Enabled : in Boolean)
+   procedure Set_Sleep_After_Tx (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Configures the DW1000 to enter sleep more (or not) after transmitting a
    --  frame.
    --
@@ -888,7 +883,7 @@ is
                           Rx_On_Time  : in RX_SNIFF_SNIFF_ONT_Field;
                           Rx_Off_Time : in Sniff_Off_Time)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Mode, Rx_On_Time, Rx_Off_Time)),
+     Depends => (DW1000.BSP.Device_State =>+ (Mode, Rx_On_Time, Rx_Off_Time)),
      Pre => (if Mode = Sniff then Rx_Off_Time > 0.0);
    --  Enables or disables the receiver sniff mode.
    --
@@ -917,9 +912,9 @@ is
    --  This procedure configures the following registers:
    --    * RX_SNIFF
 
-   procedure Set_Auto_Rx_Reenable (Enabled : in Boolean)
+   procedure Set_Auto_Rx_Reenable (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Enable or disable the Rx auto re-enable feature.
    --
    --  This feature has different behaviour depending on whether or not the
@@ -941,9 +936,9 @@ is
    --  This procedure configures the following registers:
    --    * SYS_CFG
 
-   procedure Set_Rx_Double_Buffer (Enabled : in Boolean)
+   procedure Set_Rx_Double_Buffer (Enable : in Boolean)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Enabled);
+     Depends => (DW1000.BSP.Device_State =>+ Enable);
    --  Configures double-buffer mode.
    --
    --  By default the DW1000 operates in single-buffer mode. Double-buffer
@@ -958,7 +953,7 @@ is
 
    procedure Set_Rx_Frame_Wait_Timeout (Timeout : in Frame_Wait_Timeout_Time)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Timeout);
+     Depends => (DW1000.BSP.Device_State =>+ Timeout);
    --  Configure the receive timeout.
    --
    --  When the receiver is enabled the receive timeout is started.
@@ -978,9 +973,9 @@ is
    --     E.g. a value of 0.001 is 1 millisecond. The maximum permitted value
    --     is 0.067_215_385, i.e. a little over 67 milliseconds.
 
-   procedure Set_Preamble_Detect_Timeout (Timeout : in Types.Bits_16)
+   procedure Set_Preamble_Detect_Timeout (Timeout : in DRX_PRETOC_Field)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Timeout);
+     Depends => (DW1000.BSP.Device_State =>+ Timeout);
    --  Configure the preamble detection timeout.
    --
    --  When the receiver is enabled the preamble timeout is started.
@@ -1035,7 +1030,7 @@ is
      Depends =>
        (DW1000.BSP.Device_State => (DW1000.BSP.Device_State, Address),
         Data                    => (DW1000.BSP.Device_State, Address));
-   -- Reads a single byte from the Always-On block.
+   --  Reads a single byte from the Always-On block.
 
    procedure AON_Contiguous_Read (Start_Address : in     AON_ADDR_Field;
                                   Data          :    out Types.Byte_Array)
@@ -1043,11 +1038,11 @@ is
      Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
                                              Start_Address,
                                              Data),
-                 Data                    => + (DW1000.BSP.Device_State,
+                 Data                    =>+ (DW1000.BSP.Device_State,
                                                Start_Address)),
      Pre => (Data'Length <= 256
              and then Natural (Start_Address) + Data'Length <= 256);
-   -- Reads a contiguous sequence of bytes from the Always-On block.
+   --  Reads a contiguous sequence of bytes from the Always-On block.
 
    procedure AON_Scatter_Read (Addresses : in     AON_Address_Array;
                                Data      :    out Types.Byte_Array)
@@ -1055,7 +1050,7 @@ is
      Depends => (DW1000.BSP.Device_State => (DW1000.BSP.Device_State,
                                              Addresses,
                                              Data),
-                 Data                    => + (DW1000.BSP.Device_State,
+                 Data                    =>+ (DW1000.BSP.Device_State,
                                                Addresses)),
      Pre => Addresses'Length = Data'Length;
    --  Reads a non-contiguous set of bytes from the Always-on block.
@@ -1066,11 +1061,11 @@ is
 
    procedure Configure_Sleep_Count (Sleep_Count : in AON_CFG0_SLEEP_TIM_Field)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Sleep_Count);
+     Depends => (DW1000.BSP.Device_State =>+ Sleep_Count);
 
    procedure Set_XTAL_Trim (Trim : in FS_XTALT_Field)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Trim);
+     Depends => (DW1000.BSP.Device_State =>+ Trim);
 
    procedure Configure_LEDs (Tx_LED_Enable    : in Boolean;
                              Rx_LED_Enable    : in Boolean;

--- a/src/dw1000-generic_ro_register_driver.adb
+++ b/src/dw1000-generic_ro_register_driver.adb
@@ -25,17 +25,20 @@ with DW1000.Register_Driver;
 package body DW1000.Generic_RO_Register_Driver
 is
    subtype Register_Byte_Array is
-     DW1000.Types.Byte_Array(1 .. Register_Type'Size / 8);
+     DW1000.Types.Byte_Array (1 .. Register_Type'Size / 8);
 
-   procedure Deserialize(Source : in     Register_Byte_Array;
-                         Target :    out Register_Type)
+   -------------------
+   --  Deserialize  --
+   -------------------
+
+   procedure Deserialize (Source : in     Register_Byte_Array;
+                          Target :    out Register_Type)
      with Inline,
      Depends => (Target => Source),
      SPARK_Mode => On;
 
-
-   procedure Deserialize(Source : in     Register_Byte_Array;
-                         Target :    out Register_Type)
+   procedure Deserialize (Source : in     Register_Byte_Array;
+                          Target :    out Register_Type)
      with SPARK_Mode => Off
    is
       Target_Bytes : Register_Byte_Array
@@ -47,18 +50,21 @@ is
       Target_Bytes := Source;
    end Deserialize;
 
+   ------------
+   --  Read  --
+   ------------
 
-   procedure Read(Reg : out Register_Type)
+   procedure Read (Reg : out Register_Type)
    is
       Reg_Bytes : Register_Byte_Array;
 
    begin
-      DW1000.Register_Driver.Read_Register(Register_ID,
-                                           Sub_Register,
-                                           Reg_Bytes);
+      DW1000.Register_Driver.Read_Register (Register_ID,
+                                            Sub_Register,
+                                            Reg_Bytes);
 
-      Deserialize(Source => Reg_Bytes,
-                  Target => Reg);
+      Deserialize (Source => Reg_Bytes,
+                   Target => Reg);
    end Read;
 
 end DW1000.Generic_RO_Register_Driver;

--- a/src/dw1000-generic_ro_register_driver.adb
+++ b/src/dw1000-generic_ro_register_driver.adb
@@ -39,8 +39,9 @@ is
 
    procedure Deserialize (Source : in     Register_Byte_Array;
                           Target :    out Register_Type)
-     with SPARK_Mode => Off
-   is
+     with SPARK_Mode => Off is
+
+      --  Overlay a byte array onto the target register value.
       Target_Bytes : Register_Byte_Array
         with Import,
         Convention => Ada,
@@ -54,8 +55,7 @@ is
    --  Read  --
    ------------
 
-   procedure Read (Reg : out Register_Type)
-   is
+   procedure Read (Reg : out Register_Type) is
       Reg_Bytes : Register_Byte_Array;
 
    begin

--- a/src/dw1000-generic_ro_register_driver.ads
+++ b/src/dw1000-generic_ro_register_driver.ads
@@ -41,7 +41,7 @@ generic
 package DW1000.Generic_RO_Register_Driver
 is
 
-   procedure Read(Reg : out Register_Type)
+   procedure Read (Reg : out Register_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => DW1000.BSP.Device_State,
                  Reg                     => DW1000.BSP.Device_State),

--- a/src/dw1000-generic_rw_register_driver.adb
+++ b/src/dw1000-generic_rw_register_driver.adb
@@ -45,8 +45,7 @@ is
    --  Read  --
    ------------
 
-   procedure Read (Reg : out Register_Type)
-   is
+   procedure Read (Reg : out Register_Type) is
    begin
       Read_Driver.Read (Reg);
    end Read;
@@ -55,8 +54,7 @@ is
    --  Write  --
    -------------
 
-   procedure Write (Reg : in Register_Type)
-   is
+   procedure Write (Reg : in Register_Type) is
    begin
       Write_Driver.Write (Reg);
    end Write;

--- a/src/dw1000-generic_rw_register_driver.adb
+++ b/src/dw1000-generic_rw_register_driver.adb
@@ -26,7 +26,11 @@ with DW1000.Generic_WO_Register_Driver;
 package body DW1000.Generic_RW_Register_Driver
 is
 
-   -- Reuse the Read/Write procedures from the other drivers.
+   -------------------
+   --  Read_Driver  --
+   -------------------
+
+   --  Reuse the Read/Write procedures from the other drivers.
    package Read_Driver is new Generic_RO_Register_Driver
      (Register_Type,
       Register_ID,
@@ -37,18 +41,24 @@ is
       Register_ID,
       Sub_Register);
 
+   ------------
+   --  Read  --
+   ------------
 
-   procedure Read(Reg : out Register_Type)
+   procedure Read (Reg : out Register_Type)
    is
    begin
-      Read_Driver.Read(Reg);
+      Read_Driver.Read (Reg);
    end Read;
 
+   -------------
+   --  Write  --
+   -------------
 
-   procedure Write(Reg : in Register_Type)
+   procedure Write (Reg : in Register_Type)
    is
    begin
-      Write_Driver.Write(Reg);
+      Write_Driver.Write (Reg);
    end Write;
 
 end DW1000.Generic_RW_Register_Driver;

--- a/src/dw1000-generic_rw_register_driver.ads
+++ b/src/dw1000-generic_rw_register_driver.ads
@@ -41,17 +41,17 @@ generic
 package DW1000.Generic_RW_Register_Driver
 is
 
-   procedure Read(Reg : out Register_Type)
+   procedure Read (Reg : out Register_Type)
      with Inline,
      Global => (In_Out => DW1000.BSP.Device_State),
      Depends => (DW1000.BSP.Device_State => DW1000.BSP.Device_State,
                  Reg                     => DW1000.BSP.Device_State),
      SPARK_Mode => On;
 
-   procedure Write(Reg : in Register_Type)
+   procedure Write (Reg : in Register_Type)
      with Inline,
      Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Reg),
+     Depends => (DW1000.BSP.Device_State =>+ Reg),
      SPARK_Mode => On;
 
 end DW1000.Generic_RW_Register_Driver;

--- a/src/dw1000-generic_wo_register_driver.adb
+++ b/src/dw1000-generic_wo_register_driver.adb
@@ -32,8 +32,7 @@ is
         (Source => Register_Type,
          Target => Register_Byte_Array);
 
-   procedure Write (Reg : in Register_Type)
-   is
+   procedure Write (Reg : in Register_Type) is
       Reg_Bytes : Register_Byte_Array;
 
    begin

--- a/src/dw1000-generic_wo_register_driver.adb
+++ b/src/dw1000-generic_wo_register_driver.adb
@@ -26,24 +26,22 @@ with DW1000.Register_Driver;
 package body DW1000.Generic_WO_Register_Driver
 is
    subtype Register_Byte_Array is
-     DW1000.Types.Byte_Array(1 .. Register_Type'Size / 8);
-
+     DW1000.Types.Byte_Array (1 .. Register_Type'Size / 8);
 
    function Register_To_Bytes is new Ada.Unchecked_Conversion
         (Source => Register_Type,
          Target => Register_Byte_Array);
 
-
-   procedure Write(Reg : in Register_Type)
+   procedure Write (Reg : in Register_Type)
    is
       Reg_Bytes : Register_Byte_Array;
 
    begin
-      Reg_Bytes := Register_To_Bytes(Reg);
+      Reg_Bytes := Register_To_Bytes (Reg);
 
-      DW1000.Register_Driver.Write_Register(Register_ID,
-                                            Sub_Register,
-                                            Reg_Bytes);
+      DW1000.Register_Driver.Write_Register (Register_ID,
+                                             Sub_Register,
+                                             Reg_Bytes);
    end Write;
 
 end DW1000.Generic_WO_Register_Driver;

--- a/src/dw1000-generic_wo_register_driver.ads
+++ b/src/dw1000-generic_wo_register_driver.ads
@@ -41,9 +41,9 @@ generic
 package DW1000.Generic_WO_Register_Driver
 is
 
-   procedure Write(Reg : in Register_Type)
+   procedure Write (Reg : in Register_Type)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + Reg),
+     Depends => (DW1000.BSP.Device_State =>+ Reg),
      SPARK_Mode => On;
 
 end DW1000.Generic_WO_Register_Driver;

--- a/src/dw1000-ranging-double_sided.adb
+++ b/src/dw1000-ranging-double_sided.adb
@@ -25,14 +25,19 @@ with DW1000.Types; use DW1000.Types;
 package body DW1000.Ranging.Double_Sided
 with SPARK_Mode => On
 is
+
+   ------------------------
+   --  Compute_Distance  --
+   ------------------------
+
    function Compute_Distance
      (Tag_Tx_Poll_Timestamp     : in Fine_System_Time;
       Anchor_Rx_Poll_Timestamp  : in Fine_System_Time;
       Anchor_Tx_Resp_Timestamp  : in Fine_System_Time;
       Tag_Rx_Resp_Timestamp     : in Fine_System_Time;
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
-      Anchor_Rx_Final_Timestamp : in Fine_System_Time) return Biased_Distance
-   is
+      Anchor_Rx_Final_Timestamp : in Fine_System_Time) return Biased_Distance is
+
       type System_Time_Span_Div2 is
       delta System_Time_Span'Delta / 2.0
       range 0.0 .. System_Time_Span'Last --  need the same range as System_Time_Span
@@ -91,6 +96,9 @@ is
       return Biased_Distance (TOF_Float * Speed_Of_Light_In_Air);
    end Compute_Distance;
 
+   ------------------------
+   --  Compute_Distance  --
+   ------------------------
 
    function Compute_Distance
      (Tag_Tx_Poll_Timestamp     : in Fine_System_Time;
@@ -100,8 +108,7 @@ is
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Final_Timestamp : in Fine_System_Time;
       Channel                   : in DW1000.Driver.Channel_Number;
-      PRF                       : in DW1000.Driver.PRF_Type) return Meters
-   is
+      PRF                       : in DW1000.Driver.PRF_Type) return Meters is
       Distance_With_Bias : Biased_Distance;
 
    begin

--- a/src/dw1000-ranging-double_sided.ads
+++ b/src/dw1000-ranging-double_sided.ads
@@ -60,7 +60,6 @@ is
    --     measurement contains a bias which must be removed to obtain a more
    --     accurate measurement.
 
-
    function Compute_Distance
      (Tag_Tx_Poll_Timestamp     : in Fine_System_Time;
       Anchor_Rx_Poll_Timestamp  : in Fine_System_Time;

--- a/src/dw1000-ranging-single_sided.adb
+++ b/src/dw1000-ranging-single_sided.adb
@@ -25,12 +25,17 @@ with DW1000.Types; use DW1000.Types;
 package body DW1000.Ranging.Single_Sided
 with SPARK_Mode => On
 is
+
+   ------------------------
+   --  Compute_Distance  --
+   ------------------------
+
    function Compute_Distance
      (Tag_Tx_Poll_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Poll_Timestamp : in Fine_System_Time;
       Anchor_Tx_Resp_Timestamp : in Fine_System_Time;
-      Tag_Rx_Resp_Timestamp    : in Fine_System_Time) return Biased_Distance
-   is
+      Tag_Rx_Resp_Timestamp    : in Fine_System_Time) return Biased_Distance is
+
       type System_Time_Span_Div2 is
       delta System_Time_Span'Delta / 2.0
       range 0.0 .. System_Time_Span'Last / 2.0
@@ -67,6 +72,9 @@ is
       return Biased_Distance (TOF_Float * Speed_Of_Light_In_Air);
    end Compute_Distance;
 
+   ------------------------
+   --  Compute_Distance  --
+   ------------------------
 
    function Compute_Distance
      (Tag_Tx_Poll_Timestamp    : in Fine_System_Time;
@@ -74,8 +82,8 @@ is
       Anchor_Tx_Resp_Timestamp : in Fine_System_Time;
       Tag_Rx_Resp_Timestamp    : in Fine_System_Time;
       Channel                  : in DW1000.Driver.Channel_Number;
-      PRF                      : in DW1000.Driver.PRF_Type) return Meters
-   is
+      PRF                      : in DW1000.Driver.PRF_Type) return Meters is
+
       Distance_With_Bias : Biased_Distance;
 
    begin
@@ -90,6 +98,5 @@ is
          Channel           => Channel,
          PRF               => PRF);
    end Compute_Distance;
-
 
 end DW1000.Ranging.Single_Sided;

--- a/src/dw1000-ranging.adb
+++ b/src/dw1000-ranging.adb
@@ -91,7 +91,6 @@ is
          35 => 63.75,
          36 => 63.75);
 
-
    Correction_Table_Ch2_16MHz : constant Correction_Table
      := (0 => 0.25,
          1 => 0.50,
@@ -588,11 +587,15 @@ is
    -------------------------
 
    function Lookup_Correction (Measured_Distance : in Meters;
-                               Table           : in Correction_Table)
+                               Table             : in Correction_Table)
                                return Correction_Distance
      with Global => null,
-     Pre => Table'Length <= 68
-   is
+     Pre => Table'Length <= 68;
+
+   function Lookup_Correction (Measured_Distance : in Meters;
+                               Table             : in Correction_Table)
+                               return Correction_Distance is
+
       Distance_25cm : Short_Distance;
 
       I : Natural;
@@ -632,8 +635,7 @@ is
    function Remove_Ranging_Bias
      (Measured_Distance : in Biased_Distance;
       Channel           : in DW1000.Driver.Channel_Number;
-      PRF               : in DW1000.Driver.PRF_Type) return Meters
-   is
+      PRF               : in DW1000.Driver.PRF_Type) return Meters is
       Initial_Distance : constant Meters := Meters (Measured_Distance);
 
       Correction : Correction_Distance;

--- a/src/dw1000-reception_quality.adb
+++ b/src/dw1000-reception_quality.adb
@@ -45,8 +45,8 @@ is
    --  Argument_Error function.
 
    function Log10 (X : in Long_Float) return Long_Float
-     with SPARK_Mode => Off
-   is
+     with SPARK_Mode => Off is
+
       package Long_Float_Math is
         new Ada.Numerics.Generic_Elementary_Functions (Long_Float);
    begin
@@ -61,8 +61,8 @@ is
                            RXPACC_NOSAT        : in RXPACC_NOSAT_Field;
                            RXBR                : in RX_FINFO_RXBR_Field;
                            SFD_LENGTH          : in Bits_8;
-                           Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field
-   is
+                           Non_Standard_SFD    : in Boolean) return RX_FINFO_RXPACC_Field is
+
       RXPACC_Adjustment : RX_FINFO_RXPACC_Field;
 
    begin
@@ -106,8 +106,8 @@ is
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
                                   RXPACC        : in RX_FINFO_RXPACC_Field;
                                   CIR_PWR       : in RX_FQUAL_CIR_PWR_Field)
-                                  return Float
-   is
+                                  return Float is
+
       subtype Numerator_Range is Long_Float
       range 2.0**17 .. (2.0**16 - 1.0) * 2.0**17;
 
@@ -191,8 +191,8 @@ is
                                      F2            : in RX_FQUAL_FP_AMPL2_Field;
                                      F3            : in RX_FQUAL_FP_AMPL3_Field;
                                      RXPACC        : in RX_FINFO_RXPACC_Field)
-                                     return Float
-   is
+                                     return Float is
+
       subtype F_Range is Long_Float range 0.0 .. (2.0**16 - 1.0)**2;
 
       subtype Numerator_Range  is Long_Float
@@ -282,8 +282,8 @@ is
 
    function Transmitter_Clock_Offset (RXTOFS  : in RX_TTCKO_RXTOFS_Field;
                                       RXTTCKI : in RX_TTCKI_RXTTCKI_Field)
-                                      return Long_Float
-   is
+                                      return Long_Float is
+
       Offset   : Long_Float;
       Interval : Long_Float;
    begin

--- a/src/dw1000-reception_quality.ads
+++ b/src/dw1000-reception_quality.ads
@@ -63,7 +63,6 @@ is
    --  @param Non_Standard_SFD Determines whether or not the standards-defined
    --     SFD sequence is used, or the DecaWave defined sequence is used.
 
-
    function Receive_Signal_Power (Use_16MHz_PRF : in Boolean;
                                   RXPACC        : in RX_FINFO_RXPACC_Field;
                                   CIR_PWR       : in RX_FQUAL_CIR_PWR_Field)
@@ -84,7 +83,6 @@ is
    --
    --  @return The estimated receive signal power in dBm. The theoretical range
    --     is -166.90 dBm to -14.43 dBm.
-
 
    function First_Path_Signal_Power (Use_16MHz_PRF : in Boolean;
                                      F1            : in RX_TIME_FP_AMPL1_Field;
@@ -112,7 +110,6 @@ is
    --
    --  @return The estimated first path power in dBm. The theoretical range
    --     is -218.07 dBm to -12.67 dBm.
-
 
    function Transmitter_Clock_Offset (RXTOFS  : in RX_TTCKO_RXTOFS_Field;
                                       RXTTCKI : in RX_TTCKI_RXTTCKI_Field)

--- a/src/dw1000-register_driver.adb
+++ b/src/dw1000-register_driver.adb
@@ -42,10 +42,14 @@ is
      (Source => Long_Indexed_Header,
       Target => Long_Indexed_Header_Bytes);
 
+   ---------------------
+   --  Read_Register  --
+   ---------------------
+
    procedure Read_Register (Register_ID : in     DW1000.Types.Bits_6;
                             Sub_Address : in     DW1000.Types.Bits_15;
-                            Data        :    out DW1000.Types.Byte_Array)
-   is
+                            Data        :    out DW1000.Types.Byte_Array) is
+
       use type Types.Bits_15;
 
    begin
@@ -91,10 +95,14 @@ is
       end if;
    end Read_Register;
 
+   ----------------------
+   --  Write_Register  --
+   ----------------------
+
    procedure Write_Register (Register_ID : in DW1000.Types.Bits_6;
                              Sub_Address : in DW1000.Types.Bits_15;
-                             Data        : in DW1000.Types.Byte_Array)
-   is
+                             Data        : in DW1000.Types.Byte_Array) is
+
       use type Types.Bits_15;
 
    begin

--- a/src/dw1000-register_driver.adb
+++ b/src/dw1000-register_driver.adb
@@ -26,9 +26,9 @@ package body DW1000.Register_Driver
 with SPARK_Mode => On
 is
 
-   subtype Non_Indexed_Header_Bytes   is Types.Byte_Array(1 .. 1);
-   subtype Short_Indexed_Header_Bytes is Types.Byte_Array(1 .. 2);
-   subtype Long_Indexed_Header_Bytes  is Types.Byte_Array(1 .. 3);
+   subtype Non_Indexed_Header_Bytes   is Types.Byte_Array (1 .. 1);
+   subtype Short_Indexed_Header_Bytes is Types.Byte_Array (1 .. 2);
+   subtype Long_Indexed_Header_Bytes  is Types.Byte_Array (1 .. 3);
 
    function To_Bytes is new Ada.Unchecked_Conversion
      (Source => Non_Indexed_Header,
@@ -42,9 +42,9 @@ is
      (Source => Long_Indexed_Header,
       Target => Long_Indexed_Header_Bytes);
 
-   procedure Read_Register(Register_ID : in     DW1000.Types.Bits_6;
-                           Sub_Address : in     DW1000.Types.Bits_15;
-                           Data        :    out DW1000.Types.Byte_Array)
+   procedure Read_Register (Register_ID : in     DW1000.Types.Bits_6;
+                            Sub_Address : in     DW1000.Types.Bits_15;
+                            Data        :    out DW1000.Types.Byte_Array)
    is
       use type Types.Bits_15;
 
@@ -56,8 +56,8 @@ is
                Sub_Index   => Not_Present,
                Register_ID => Register_ID);
          begin
-            BSP.Read_Transaction(Header => To_Bytes (Header),
-                                 Data   => Data);
+            BSP.Read_Transaction (Header => To_Bytes (Header),
+                                  Data   => Data);
          end;
 
       elsif Sub_Address < 2**7 then
@@ -69,8 +69,8 @@ is
                Extended_Address     => Not_Extended,
                Register_Sub_Address => Types.Bits_7 (Sub_Address));
          begin
-            BSP.Read_Transaction(Header => To_Bytes (Header),
-                                 Data   => Data);
+            BSP.Read_Transaction (Header => To_Bytes (Header),
+                                  Data   => Data);
          end;
 
       else
@@ -84,16 +84,16 @@ is
                  Types.Bits_7 (Sub_Address and 16#7F#),
                Register_Sub_Address_MSB => Types.Bits_8 (Sub_Address / 2**7));
          begin
-            BSP.Read_Transaction(Header => To_Bytes (Header),
-                                 Data   => Data);
+            BSP.Read_Transaction (Header => To_Bytes (Header),
+                                  Data   => Data);
          end;
 
       end if;
    end Read_Register;
 
-   procedure Write_Register(Register_ID : in DW1000.Types.Bits_6;
-                            Sub_Address : in DW1000.Types.Bits_15;
-                            Data        : in DW1000.Types.Byte_Array)
+   procedure Write_Register (Register_ID : in DW1000.Types.Bits_6;
+                             Sub_Address : in DW1000.Types.Bits_15;
+                             Data        : in DW1000.Types.Byte_Array)
    is
       use type Types.Bits_15;
 
@@ -105,8 +105,8 @@ is
                Sub_Index   => Not_Present,
                Register_ID => Register_ID);
          begin
-            BSP.Write_Transaction(Header => To_Bytes (Header),
-                                  Data   => Data);
+            BSP.Write_Transaction (Header => To_Bytes (Header),
+                                   Data   => Data);
          end;
 
       elsif Sub_Address < 2**7 then
@@ -118,8 +118,8 @@ is
                Extended_Address     => Not_Extended,
                Register_Sub_Address => Types.Bits_7 (Sub_Address));
          begin
-            BSP.Write_Transaction(Header => To_Bytes (Header),
-                                  Data   => Data);
+            BSP.Write_Transaction (Header => To_Bytes (Header),
+                                   Data   => Data);
          end;
 
       else
@@ -133,8 +133,8 @@ is
                  Types.Bits_7 (Sub_Address and 16#7F#),
                Register_Sub_Address_MSB => Types.Bits_8 (Sub_Address / 2**7));
          begin
-            BSP.Write_Transaction(Header => To_Bytes (Header),
-                                  Data   => Data);
+            BSP.Write_Transaction (Header => To_Bytes (Header),
+                                   Data   => Data);
          end;
       end if;
    end Write_Register;

--- a/src/dw1000-register_driver.ads
+++ b/src/dw1000-register_driver.ads
@@ -43,7 +43,6 @@ is
    --
    --  This bit is only used for the 2 octet and 3 octet long headers.
 
-
    type Non_Indexed_Header is record
       Register_ID : DW1000.Types.Bits_6 := 0;
       Sub_Index   : Sub_Index_Type      := Not_Present;
@@ -76,7 +75,6 @@ is
    --
    --  In this header the Sub_Index field must always be set to Present
    --  and the Extended_Address field must always be set to Not_Extended.
-
 
    for Short_Indexed_Header use record
       Register_ID          at 0 range  0 ..  5;
@@ -112,23 +110,22 @@ is
       Register_Sub_Address_MSB at 0 range 16 .. 23;
    end record;
 
-
-   procedure Read_Register(Register_ID : in     DW1000.Types.Bits_6;
-                           Sub_Address : in     DW1000.Types.Bits_15;
-                           Data        :    out DW1000.Types.Byte_Array)
+   procedure Read_Register (Register_ID : in     DW1000.Types.Bits_6;
+                            Sub_Address : in     DW1000.Types.Bits_15;
+                            Data        :    out DW1000.Types.Byte_Array)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Register_ID, Sub_Address, Data),
+     Depends => (DW1000.BSP.Device_State =>+ (Register_ID, Sub_Address, Data),
                  Data                    => (DW1000.BSP.Device_State,
                                              Register_ID,
                                              Sub_Address)),
      Pre => Data'Length > 0;
    --  Read a register on the DW1000.
 
-   procedure Write_Register(Register_ID : in DW1000.Types.Bits_6;
-                            Sub_Address : in DW1000.Types.Bits_15;
-                            Data        : in DW1000.Types.Byte_Array)
+   procedure Write_Register (Register_ID : in DW1000.Types.Bits_6;
+                             Sub_Address : in DW1000.Types.Bits_15;
+                             Data        : in DW1000.Types.Byte_Array)
      with Global => (In_Out => DW1000.BSP.Device_State),
-     Depends => (DW1000.BSP.Device_State => + (Register_ID, Sub_Address, Data)),
+     Depends => (DW1000.BSP.Device_State =>+ (Register_ID, Sub_Address, Data)),
      Pre => Data'Length > 0;
    --  Write to a register on the DW1000.
 

--- a/src/dw1000-register_types.ads
+++ b/src/dw1000-register_types.ads
@@ -33,7 +33,7 @@ with SPARK_Mode => On
 is
 
    ----------------------------------------------------------------------------
-   -- DEV_ID register file
+   --  DEV_ID register file
 
    type DEV_ID_Type is record
       REV    : Types.Bits_4  := 2#0000#;
@@ -53,7 +53,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- EUI register file
+   --  EUI register file
 
    type EUI_Type is record
       EUI : Types.Bits_64;
@@ -67,7 +67,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- PANDADR register file
+   --  PANDADR register file
 
    type PANADR_Type is record
       SHORT_ADDR : Types.Bits_16 := 16#FFFF#;
@@ -83,7 +83,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- SYS_CFG register file
+   --  SYS_CFG register file
 
    type SYS_CFG_FFEN_Field is
      (Disabled,
@@ -292,7 +292,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- SYS_TIME register file
+   --  SYS_TIME register file
 
    type SYS_TIME_Type is record
       SYS_TIME : System_Time.Coarse_System_Time;
@@ -302,7 +302,7 @@ is
      Scalar_Storage_Order => System.Low_Order_First;
 
    ----------------------------------------------------------------------------
-   -- TX_FCTRL register file
+   --  TX_FCTRL register file
 
    type TX_FCTRL_TFLEN_Field is range 0 .. 127
      with Size => 7;
@@ -384,10 +384,10 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- TX_BUFFER register file
+   --  TX_BUFFER register file
 
    type TX_BUFFER_Type is record
-      TX_BUFFER : Types.Byte_Array(1 .. 1024) := (others => 0);
+      TX_BUFFER : Types.Byte_Array (1 .. 1024) := (others => 0);
    end record
      with Size => 8192,
      Bit_Order => System.Low_Order_First,
@@ -398,7 +398,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- DX_TIME register file
+   --  DX_TIME register file
 
    type DX_TIME_Type is record
       DX_TIME : System_Time.Coarse_System_Time := 0.0;
@@ -408,7 +408,7 @@ is
      Scalar_Storage_Order => System.Low_Order_First;
 
    ----------------------------------------------------------------------------
-   -- RX_FWTO register file
+   --  RX_FWTO register file
 
    type RX_FWTO_Type is record
       RXFWTO : System_Time.Frame_Wait_Timeout_Time := 0.0;
@@ -422,7 +422,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- SYS_CTRL register file
+   --  SYS_CTRL register file
 
    type SYS_CTRL_SFCST_Field is
      (Not_Suppressed,
@@ -518,7 +518,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- SYS_MASK register file
+   --  SYS_MASK register file
 
    type SYS_MASK_Mask_Field is
      (Masked,
@@ -603,7 +603,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- SYS_STATUS register file
+   --  SYS_STATUS register file
 
    type SYS_STATUS_Type is record
       IRQS      : Types.Bits_1  := 0;
@@ -691,7 +691,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_FINFO register file
+   --  RX_FINFO register file
 
    type RX_FINFO_RXFLEN_Field is range 0 .. 127
      with Size => 7;
@@ -769,10 +769,10 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_BUFFER register file
+   --  RX_BUFFER register file
 
    type RX_BUFFER_Type is record
-      RX_BUFFER : Types.Byte_Array(1 .. 1024) := (others => 0);
+      RX_BUFFER : Types.Byte_Array (1 .. 1024) := (others => 0);
    end record
      with Size => 8192,
      Bit_Order => System.Low_Order_First,
@@ -783,7 +783,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_FQUAL register file
+   --  RX_FQUAL register file
 
    type RX_FQUAL_STD_NOISE_Field is range 0 .. 2**16 - 1
      with Size => 16;
@@ -819,7 +819,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_TTCKI register file
+   --  RX_TTCKI register file
 
    type RX_TTCKI_RXTTCKI_Field is range 0 .. 2**32 - 1
      with Size => 32;
@@ -837,7 +837,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_TTCKO register file
+   --  RX_TTCKO register file
 
    type RX_TTCKO_RXTOFS_Field is range -2**18 .. 2**18 - 1
      with Size => 19;
@@ -881,7 +881,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_TIME register file
+   --  RX_TIME register file
 
    type RX_TIME_FP_INDEX_Field is range 0 .. 2**16 - 1
      with Size => 16;
@@ -897,7 +897,7 @@ is
       FP_AMPL1 : RX_TIME_FP_AMPL1_Field         := 0;
       RX_RAWST : System_Time.Coarse_System_Time := 0.0;
    end record
-     with Size => 8*14,
+     with Size => 8 * 14,
      Bit_Order => System.Low_Order_First,
      Scalar_Storage_Order => System.Low_Order_First;
 
@@ -909,7 +909,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- TX_TIME register file
+   --  TX_TIME register file
 
    type TX_TIME_Type is record
       TX_STAMP : System_Time.Fine_System_Time   := 0.0;
@@ -925,7 +925,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- TX_ANTD register file
+   --  TX_ANTD register file
 
    type TX_ANTD_Type is record
       TX_ANTD : System_Time.Antenna_Delay_Time := 0.0;
@@ -943,11 +943,11 @@ is
 
    type SYS_STATE_TX_STATE_Field is
      (Idle,
-      Preamble,
-      SFD,
-      PHR,
-      SDE,
-      DATA,
+      Transmitting_Preamble,
+      Transmitting_SFD,
+      Transmitting_PHR,
+      Transmitting_SDE,
+      Transmitting_DATA,
       Reserved_0110,
       Reserved_0111,
       Reserved_1000,
@@ -1044,7 +1044,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- ACK_RESP_T register file
+   --  ACK_RESP_T register file
 
    type ACK_RESP_T_ACK_TIM_Field is range 0 .. 255
      with Size => 8;
@@ -1069,7 +1069,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RX_SNIFF register file
+   --  RX_SNIFF register file
 
    type RX_SNIFF_SNIFF_ONT_Field is range 0 .. 15
      with Size => 4;
@@ -1097,7 +1097,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- TX_POWER register file
+   --  TX_POWER register file
 
    type TX_POWER_COARSE_Field is
      (Gain_15_dB,
@@ -1152,7 +1152,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- CHAN_CTRL register file
+   --  CHAN_CTRL register file
 
    type CHAN_CTRL_Channel_Field is range 0 .. 15
      with Size => 4;
@@ -1221,21 +1221,21 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- USR_SFD register file
+   --  USR_SFD register file
 
    type USR_SFD_Type is record
-      Sub_Registers : Types.Byte_Array(0 .. 40);
+      Sub_Registers : Types.Byte_Array (0 .. 40);
    end record
-     with Size => 41*8,
+     with Size => 41 * 8,
      Bit_Order => System.Low_Order_First,
      Scalar_Storage_Order => System.Low_Order_First;
 
    for USR_SFD_Type use record
-      Sub_Registers at 0 range 0 .. 41*8 - 1;
+      Sub_Registers at 0 range 0 .. (41 * 8) - 1;
    end record;
 
    ----------------------------------------------------------------------------
-   -- AGC_CTRL register file
+   --  AGC_CTRL register file
 
    ------------------------------
    --  AGC_CTRL1 sub-register  --
@@ -1352,7 +1352,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- EXT_SYNC register file
+   --  EXT_SYNC register file
 
    ---------------------------
    -- EC_CTRL sub-register  --
@@ -1453,7 +1453,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- ACC_MEM register file
+   --  ACC_MEM register file
 
    type ACC_MEM_Number_Type is range -32_768 .. 32_767
      with Size => 16;
@@ -1471,21 +1471,21 @@ is
       Imag at 2 range 0 .. 15;
    end record;
 
-   type ACC_MEM_CIR_Array is array(Types.Index range <>) of ACC_MEM_Sample_Type;
+   type ACC_MEM_CIR_Array is array (Types.Index range <>) of ACC_MEM_Sample_Type;
 
    type ACC_MEM_Type is record
       CIR : ACC_MEM_CIR_Array (0 .. 1015);
    end record
-     with Size => 4064*8,
+     with Size => 4064 * 8,
      Bit_Order => System.Low_Order_First,
      Scalar_Storage_Order => System.Low_Order_First;
 
    for ACC_MEM_Type use record
-      CIR at 0 range 0 .. (4064*8) - 1;
+      CIR at 0 range 0 .. (4064 * 8) - 1;
    end record;
 
    ----------------------------------------------------------------------------
-   -- GPIO_CTRL register file
+   --  GPIO_CTRL register file
 
    -----------------------------
    -- GPIO_MODE sub-register  --
@@ -2014,7 +2014,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- DRX_CONF register file
+   --  DRX_CONF register file
 
    ------------------------------
    -- DRX_TUNE0b sub-register  --
@@ -2070,7 +2070,7 @@ is
    --  Preamble lengths > 1024 symbols, for 110 kbps operation
 
    DRX_TUNE1b_850K_6M8 : constant DRX_TUNE1b_Field := 16#0020#;
-   -- Preamble lengths 128 to 1024 symbols, for 850 kbps and 6.8 Mbps operation
+   --  Preamble lengths 128 to 1024 symbols, for 850 kbps and 6.8 Mbps operation
 
    DRX_TUNE1b_6M8      : constant DRX_TUNE1b_Field := 16#0010#;
    --  Preamble length = 64 symbols, for 6.8 Mbps operation
@@ -2189,7 +2189,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- RF_CONF register file
+   --  RF_CONF register file
 
    ---------------------------
    -- RF_CONF sub-register  --
@@ -2338,7 +2338,7 @@ is
 
    type LDOTUNE_Field is new Bits_40;
 
-   type LDOTUNE_Type is Record
+   type LDOTUNE_Type is record
       LDOTUNE : LDOTUNE_Field := 16#88_8888_8888#;
    end record
      with Size => 40,
@@ -2350,7 +2350,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- TX_CAL register file
+   --  TX_CAL register file
 
    ---------------------------
    -- TC_SARC sub-register  --
@@ -2537,7 +2537,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- FS_CTRL register file
+   --  FS_CTRL register file
 
    -----------------------------
    -- FS_PLLCFG sub-register  --
@@ -2611,7 +2611,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- AON register file
+   --  AON register file
 
    ----------------------------
    -- AON_WCFG sub-register  --
@@ -2680,7 +2680,7 @@ is
       Reserved_2 : Types.Bits_2 := 0;
       Reserved_3 : Types.Bits_2 := 0;
       Reserved_4 : Types.Bits_3 := 0;
-   end Record
+   end record
      with Size => 16,
      Bit_Order => System.Low_Order_First,
      Scalar_Storage_Order => System.Low_Order_First;
@@ -2909,7 +2909,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- OTP_IF register file
+   --  OTP_IF register file
 
    ----------------------------
    -- OTP_WDAT sub-register  --
@@ -3124,7 +3124,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- LDE_IF register file
+   --  LDE_IF register file
 
    ------------------------------
    -- LDE_THRESH sub-register  --
@@ -3283,7 +3283,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- DIG_DIAG register file
+   --  DIG_DIAG register file
 
    ----------------------------
    -- EVC_CTRL sub-register  --
@@ -3296,7 +3296,7 @@ is
    --  Event Counters Enable.
 
    type EVC_CTRL_EVC_CLR_Field is
-     (No_action,
+     (No_Action,
       Clear_Counters)
      with Size => 1;
    --  Event Counters Clear.
@@ -3578,7 +3578,7 @@ is
    end record;
 
    ----------------------------------------------------------------------------
-   -- PMSC register file
+   --  PMSC register file
 
    type PMSC_CTRL0_SYSCLKS_Field is
      (Auto,
@@ -3755,7 +3755,7 @@ is
      (Disabled,
       Enabled)
      with Size => 1;
-   -- This enables a special 1 GHz clock used for some external SYNC modes.
+   --  This enables a special 1 GHz clock used for some external SYNC modes.
 
    type PMSC_CTRL1_LDERUNE_Field is
      (Disabled,

--- a/src/dw1000-registers.ads
+++ b/src/dw1000-registers.ads
@@ -26,20 +26,20 @@ with DW1000.Generic_RW_Register_Driver;
 with DW1000.Register_Types;
 with DW1000.Types;
 
-pragma Elaborate_All(DW1000.Generic_RO_Register_Driver);
-pragma Elaborate_All(DW1000.Generic_WO_Register_Driver);
-pragma Elaborate_All(DW1000.Generic_RW_Register_Driver);
+pragma Elaborate_All (DW1000.Generic_RO_Register_Driver);
+pragma Elaborate_All (DW1000.Generic_WO_Register_Driver);
+pragma Elaborate_All (DW1000.Generic_RW_Register_Driver);
 
--- This package defines register driver instances for each of the DW1000
--- device registers to allow for typed reading and writing each register
--- (or sub-register).
+--  This package defines register driver instances for each of the DW1000
+--  device registers to allow for typed reading and writing each register
+--  (or sub-register).
 --
--- Each register is typed, using the corresponding type defined in the package
--- DW1000.Register_Types. These types allow for easy manipulation for the
--- register's fields.
+--  Each register is typed, using the corresponding type defined in the package
+--  DW1000.Register_Types. These types allow for easy manipulation for the
+--  register's fields.
 --
--- Below is an example of modifying the receive and transmit channels from
--- the CHAN_CTRL register (package names omitted for clarity):
+--  Below is an example of modifying the receive and transmit channels from
+--  the CHAN_CTRL register (package names omitted for clarity):
 --    declare
 --       Reg : CHAN_CTRL_Type;
 --    begin
@@ -52,7 +52,7 @@ package DW1000.Registers
 with SPARK_Mode => On
 is
    ----------------------------------------------------------------------------
-   -- Register IDs
+   --  Register IDs
    DEV_ID_Reg_ID     : constant Types.Bits_6 := 16#00#;
    EUI_Reg_ID        : constant Types.Bits_6 := 16#01#;
    PANADR_Reg_ID     : constant Types.Bits_6 := 16#03#;
@@ -94,7 +94,7 @@ is
    PMSC_Reg_ID       : constant Types.Bits_6 := 16#36#;
 
    ----------------------------------------------------------------------------
-   -- Sub-Register IDs
+   --  Sub-Register IDs
 
    AGC_CTRL1_Sub_Reg_ID : constant Types.Bits_15 := 16#02#;
    AGC_TUNE1_Sub_Reg_ID : constant Types.Bits_15 := 16#04#;
@@ -189,7 +189,7 @@ is
    PMSC_LEDC_Sub_Reg_ID   : constant Types.Bits_15 := 16#28#;
 
    ----------------------------------------------------------------------------
-   -- Register Definitions
+   --  Register Definitions
 
    package DEV_ID is new DW1000.Generic_RO_Register_Driver
      (Register_Type => DW1000.Register_Types.DEV_ID_Type,
@@ -698,6 +698,5 @@ is
      (Register_Type => DW1000.Register_Types.PMSC_LEDC_Type,
       Register_ID   => PMSC_Reg_ID,
       Sub_Register  => PMSC_LEDC_Sub_Reg_ID);
-
 
 end DW1000.Registers;

--- a/src/dw1000-system_time.adb
+++ b/src/dw1000-system_time.adb
@@ -30,9 +30,10 @@ is
 
    function System_Time_Offset (Time : in Fine_System_Time;
                                 Span : in System_Time_Span)
-                                return Fine_System_Time
-   is
+                                return Fine_System_Time is
+
       Span_FST : constant Fine_System_Time := Fine_System_Time (Span);
+
    begin
       if Fine_System_Time'Last - Time >= Span_FST then
          return Time + Span_FST;
@@ -48,8 +49,7 @@ is
 
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Fine_System_Time)
-                            return System_Time_Span
-   is
+                            return System_Time_Span is
    begin
       if Start_Time <= End_Time then
          return System_Time_Span (End_Time - Start_Time);

--- a/src/dw1000-system_time.adb
+++ b/src/dw1000-system_time.adb
@@ -24,6 +24,10 @@ package body DW1000.System_Time
 with SPARK_Mode => On
 is
 
+   --------------------------
+   --  System_Time_Offset  --
+   --------------------------
+
    function System_Time_Offset (Time : in Fine_System_Time;
                                 Span : in System_Time_Span)
                                 return Fine_System_Time
@@ -37,6 +41,10 @@ is
          return Fine_System_Time'Last - Span_FST;
       end if;
    end System_Time_Offset;
+
+   ----------------------
+   --  Calculate_Span  --
+   ----------------------
 
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Fine_System_Time)

--- a/src/dw1000-system_time.ads
+++ b/src/dw1000-system_time.ads
@@ -260,13 +260,11 @@ is
      Global => null;
    --  Convert a 40-bit time span to the equivalent System_Time_Span value.
 
-
    function To_Antenna_Delay_Time (Bits : in Bits_16)
                                    return Antenna_Delay_Time
      with Inline,
      Global => null;
    --  Convert a 16-bit antenna delay register value to Antenna_Delay_Time.
-
 
    function System_Time_Offset (Time : in Fine_System_Time;
                                 Span : in System_Time_Span)
@@ -286,7 +284,6 @@ is
                                 Span : in System_Time_Span)
                                 return Fine_System_Time
    is (System_Time_Offset (Fine_System_Time (Time), Span));
-
 
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Fine_System_Time)
@@ -308,7 +305,6 @@ is
    --  17 seconds, so it is possible for the End_Time to be less than the
    --  Start_Time. This function takes this wrap-around behavior into account.
 
-
    function Calculate_Span (Start_Time : in Fine_System_Time;
                             End_Time   : in Coarse_System_Time)
                             return System_Time_Span
@@ -318,7 +314,6 @@ is
    --  Note that since the DW1000 system time wraps-around after about every
    --  17 seconds, so it is possible for the End_Time to be less than the
    --  Start_Time. This function takes this wrap-around behavior into account.
-
 
    function Calculate_Span (Start_Time : in Coarse_System_Time;
                             End_Time   : in Fine_System_Time)


### PR DESCRIPTION
To enforce a consistent style across the project a set of style checks and warnings are enabled when building the example projects.