### PR TITLE
Use a fixed-point 'Meters' type instead of floating-point.

### DIFF
--- a/src/dw1000-ranging-double_sided.adb
+++ b/src/dw1000-ranging-double_sided.adb
@@ -38,6 +38,16 @@ is
       Tag_Tx_Final_Timestamp    : in Fine_System_Time;
       Anchor_Rx_Final_Timestamp : in Fine_System_Time) return Biased_Distance is
 
+      Max_Time_Of_Flight : constant := 0.000_1;
+      --  Limit the Time of Flight to a maximum of 0.000_1 seconds (100 us).
+      --
+      --  This prevents overflow during the conversion from time of flight
+      --  to distance.
+      --
+      --  This limits the maximum computable distance to 2990 meters, but this
+      --  should be plenty as the operational range of the DW1000 is about
+      --  10 times below this limit (300 m).
+
       type System_Time_Span_Div2 is
       delta System_Time_Span'Delta / 2.0
       range 0.0 .. System_Time_Span'Last --  need the same range as System_Time_Span
@@ -47,6 +57,12 @@ is
       delta System_Time_Span'Delta / 4.0
       range 0.0 .. System_Time_Span'Last / 2.0
         with Small => System_Time_Span'Small / 4.0;
+
+      type Large_Meters is
+      delta Meters'Delta
+      range 0.0 .. (Max_Time_Of_Flight / System_Time_Span_Div4'Delta) * Speed_Of_Light_In_Vacuum;
+      --  A fixed-point type with a large enough integer part to store the
+      --  integer representation of a System_Time_Span_Div4 value.
 
       T_Roundtrip1 : constant System_Time_Span := Calculate_Span
         (Start_Time => Tag_Tx_Poll_Timestamp,
@@ -71,8 +87,7 @@ is
       Diff : System_Time_Span;
       Sum  : System_Time_Span_Div2;
 
-      TOF_I41   : Bits_41;
-      TOF_Float : Long_Float;
+      Result : Large_Meters;
 
    begin
       if (T_Reply1 > T_Roundtrip1) or (T_Reply2 > T_Roundtrip2) then
@@ -89,11 +104,25 @@ is
          Time_Of_Flight := System_Time_Span_Div4 (Sum / System_Time_Span_Div4 (2.0));
       end if;
 
-      --  Convert to floating point
-      TOF_I41   := Bits_41 (Time_Of_Flight / System_Time_Span_Div4 (System_Time_Span_Div4'Delta));
-      TOF_Float := Long_Float (TOF_I41) * System_Time_Span_Div4'Delta;
+      --  Cap ToF to 0.01 seconds to avoid overflow in the following calculations.
+      if Time_Of_Flight >= Max_Time_Of_Flight then
+         Time_Of_Flight := Max_Time_Of_Flight;
+      end if;
 
-      return Biased_Distance (TOF_Float * Speed_Of_Light_In_Air);
+      pragma Assert_And_Cut (Time_Of_Flight <= Max_Time_Of_Flight);
+
+      --  Convert the fixed-point representation to its integer represention
+      --  (in multiples of the 'Delta).
+      Result := Large_Meters (Time_Of_Flight / System_Time_Span_Div4 (System_Time_Span_Div4'Delta));
+
+      --  Multiply the ToF (s) with the speed of light (m/s) to yield
+      --  the distance (m) in meters.
+      Result := Result * Large_Meters (Speed_Of_Light_In_Vacuum);
+
+      --  Convert back from integer representation to fixed-point representation.
+      Result := Result / Large_Meters (1.0 / System_Time_Span_Div4'Delta);
+
+      return Biased_Distance (Result);
    end Compute_Distance;
 
    ------------------------

--- a/src/dw1000-ranging.adb
+++ b/src/dw1000-ranging.adb
@@ -611,7 +611,7 @@ is
          --  This is equivalent to:
          --     Distance_25cm := Short_Distance (Measured_Distance);
          Distance_25cm :=
-           Short_Distance'Delta * Integer (Measured_Distance / Short_Distance'Delta);
+           Short_Distance'Delta * Integer (Measured_Distance / Meters (Short_Distance'Delta));
       end if;
 
       --  Find the index of the table entry which matches the estimated distance.

--- a/src/dw1000-ranging.ads
+++ b/src/dw1000-ranging.ads
@@ -33,21 +33,11 @@ is
    Speed_Of_Light_In_Air    : constant
      := Speed_Of_Light_In_Vacuum / Air_Refractive_Index; --  meters per second
 
-   type Meters is new Float
-     range 0.0 .. Float (Speed_Of_Light_In_Air * System_Time_Span'Last);
-   --  Distance in meters.
+   type Meters is delta 0.001 range 0.0 .. 30_000.0;
+   --  Distance in meters with a resolution of 1 mm.
    --
-   --  The range of this type is constrained to the range of distance values
-   --  possible based on the maximum possible value for the time of flight.
-   --
-   --  This is a Float type (rather than a fixed-point type) to avoid some
-   --  difficulties when dealing with fixed-point types with fractional 'smalls,
-   --  for example that 1.0 can't be represented exactly. If a fixed-point type
-   --  without a fractional 'small is used then we would run into problems where
-   --  conversions from System_Time_Span to Meters would not be provable in SPARK
-   --  because the conversion would not be in the perfect result set as defined
-   --  in Annex G.2.3 of the Ada 2012 LRM. GNATprove currently limits conversions
-   --  between fixed-point types to always belong to the perfect result set.
+   --  This type is constrained to a maximum range of 30 km, which is more than
+   --  enough since the operational range of the DW1000 is limited to 300 m.
 
    type Biased_Distance is new Meters;
    --  Type for distance measurements (in meters) which includes a ranging bias.


### PR DESCRIPTION
This refactors the DW1000.Ranging packages to perform distance
calculations using fixed-point types instead of Long_Float.

Fixed-point math should be faster than floating-point math
on targets that do not have a double-precision FPU (very uncommon
on small microcontrollers).